### PR TITLE
Flac decoder improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # esp-audio-libs
 
 A collection of libraries and functions that are useful for playing audio on ESP32 devices. It includes code based on the following:
-- [esp-dsp](https://github.com/espressif/esp-dsp) assembly functions for floating point dot products, Q15 fixed point addition and multipliction by a constant.
+- [esp-dsp](https://github.com/espressif/esp-dsp) assembly functions for floating point dot products and Q15 fixed point addition and constant multipliction.
     - Author: Espressif
     - License: Apache v2.0
 - [ART-resampler](https://github.com/dbry/audio-resampler) for resampling audio, optimized with assembly dot product functions.
@@ -13,7 +13,7 @@ A collection of libraries and functions that are useful for playing audio on ESP
 - [flac-decoder](https://github.com/synesthesiam/flac-decoder) for decoding FLAC files.
     - Author: Michael Hansen
     - License: ESPHome License
-    - Port of [Simple FLACV Decoder (Python)](https://www.nayuki.io/res/simple-flac-implementation/simple-decode-flac-to-wav.py) by Project Nayuki with MIT License
+    - Port of [Simple FLAC Decoder (Python)](https://www.nayuki.io/res/simple-flac-implementation/simple-decode-flac-to-wav.py) by Project Nayuki with MIT License
 - [libHelix MP3 Decoder](https://en.wikipedia.org/wiki/Helix_Universal_Server) for decoding MP3 files
     - Author: Real Networks
     - License: RCSL

--- a/include/flac_decoder.h
+++ b/include/flac_decoder.h
@@ -49,22 +49,16 @@ const static std::vector<int16_t> FLAC_FIXED_COEFFICIENTS[] = {
  */
 class FLACDecoder {
  public:
-  /* buffer - FLAC data
-   * buffer_size - size of the data buffer
-   * min_buffer_size - min bytes in buffer before fill_buffer is called
-   */
-  FLACDecoder(uint8_t *buffer) : buffer_(buffer) {}
-
   ~FLACDecoder() { this->free_buffers(); }
 
   /* Reads FLAC header from buffer.
    * Must be called before decode_frame. */
-  FLACDecoderResult read_header(size_t buffer_length);
+  FLACDecoderResult read_header(uint8_t *buffer, size_t buffer_length);
 
   /* Decodes a single frame of audio.
    * Copies num_samples into output_buffer.
    * Use get_output_buffer_size() to allocate output_buffer. */
-  FLACDecoderResult decode_frame(size_t buffer_length, int16_t *output_buffer, uint32_t *num_samples);
+  FLACDecoderResult decode_frame(uint8_t *buffer, size_t buffer_length, int16_t *output_buffer, uint32_t *num_samples);
 
   /* Frees internal memory. */
   void free_buffers();

--- a/src/decode/flac_decoder.cpp
+++ b/src/decode/flac_decoder.cpp
@@ -8,7 +8,8 @@
 
 namespace flac {
 
-FLACDecoderResult FLACDecoder::read_header(size_t buffer_length) {
+FLACDecoderResult FLACDecoder::read_header(uint8_t *buffer, size_t buffer_length) {
+  this->buffer_ = buffer;
   this->buffer_index_ = 0;
   this->bytes_left_ = buffer_length;
   this->bit_buffer_ = 0;
@@ -240,7 +241,8 @@ FLACDecoderResult FLACDecoder::decode_frame_header_() {
   return FLAC_DECODER_SUCCESS;
 }
 
-FLACDecoderResult FLACDecoder::decode_frame(size_t buffer_length, int16_t *output_buffer, uint32_t *num_samples) {
+FLACDecoderResult FLACDecoder::decode_frame(uint8_t *buffer, size_t buffer_length, int16_t *output_buffer, uint32_t *num_samples) {
+  this->buffer_ = buffer;
   this->buffer_index_ = 0;
   this->bytes_left_ = buffer_length;
   this->out_of_data_ = false;


### PR DESCRIPTION
Passes the input buffer with each call to the flac decoder rather than setting it at construction. This approach matches the mp3 and wav decoder, and it allows more flexibility for using the component.