### PR TITLE
Refactor resampler wrapper

### DIFF
--- a/include/resampler.h
+++ b/include/resampler.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include "art_resampler.h"
 #include "art_biquad.h"
+#include "art_resampler.h"
 
 #include <algorithm>
 #include <esp_heap_caps.h>
@@ -12,6 +12,25 @@ namespace resampler {
 
 // Class that wraps the ART resampler for straightforward use
 
+struct ResamplerResults {
+  size_t frames_used;
+  size_t frames_generated;
+  size_t predicted_frames_used;
+  uint32_t clipped_samples;
+};
+
+struct ResamplerConfiguration {
+  float source_sample_rate;
+  float target_sample_rate;
+  uint8_t source_bits_per_sample;
+  uint8_t target_bits_per_sample;
+  uint8_t channels;
+  bool use_pre_or_post_filter;
+  bool subsample_interpolate;
+  uint16_t number_of_taps;
+  uint16_t number_of_filters;
+};
+
 class Resampler {
  public:
   Resampler(size_t input_buffer_samples, size_t output_buffer_samples)
@@ -19,27 +38,19 @@ class Resampler {
   ~Resampler();
 
   /// @brief Initializes the resampler
-  /// @param target_sample_rate Output sample rate
-  /// @param source_sample_rate Input sample rate
-  /// @param channels Source audio's number of channels
-  /// @param number_of_taps Number of taps per filter. Must be a multiple of 4.
-  /// @param number_of_filters Number of windowed-sinc filters. Must be greater than 1.
-  /// @param use_pre_post_filter Enable a cascading biquad filter before or after the FIR filter
-  /// @param subsample_interpolate Linearly interpolate the output sample with the two nearest sinc filters
+  /// @param config ResamplerConfiguration
   /// @return True if buffers were allocated succesfully, false otherwise.
-  bool initialize(float target_sample_rate, float source_sample_rate, uint8_t channels, uint16_t number_of_taps,
-                  uint16_t number_of_filters, bool use_pre_post_filter, bool subsample_interpolate);
+  bool initialize(ResamplerConfiguration &config);
 
   /// @brief Resamples the input samples to the initalized sample rate
-  /// @param input Pointer to int16_t source samples
-  /// @param output Pointer to write resamples int16_t samples.
+  /// @param input Pointer to source samples as a uint8_t buffer
+  /// @param output Pointer to write resampled samples as a uint8_t buffer
   /// @param input_frames_available Frames available at the input source pointer
   /// @param output_frames_free Frames free at the output sink pointer
-  /// @param frames_used size_t passed-by-reference variable that will store the number of frames processed from the
-  /// input source
-  /// @param frames_generated size_t passed-by-reference variable that will store the number of output frames generated
-  void resample(const int16_t *input, int16_t *output, size_t input_frames_available, size_t output_frames_free,
-                size_t &frames_used, size_t &frames_generated);
+  /// @param gain_db Gain (in dB) to apply before resampling
+  /// @return (ResamplerResults) Information about the number of frames used and  generated
+  ResamplerResults resample(const uint8_t *input_buffer, uint8_t *output_buffer, size_t input_frames_available,
+                            size_t output_frames_free, float gain_db);
 
  protected:
   float *float_input_buffer_{nullptr};
@@ -61,7 +72,10 @@ class Resampler {
 
   bool pre_filter_{false};
   bool post_filter_{false};
+  bool requires_resampling_{false};
 
+  uint8_t input_bits_;
+  uint8_t output_bits_;
   uint8_t channels_;
 };
 }  // namespace resampler

--- a/include/utils.h
+++ b/include/utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cmath>
+#include <stdint.h>
+
+/// @brief Converts an array of quantized samples with the specified number of bits into floating point samples.
+/// @param input_buffer Pointer to the input quantized samples aligned to the byte
+/// @param output_buffer Poitner to the output floating point samples
+/// @param num_samples Number of samples to convert
+/// @param input_bits Number of bits per sample for the quantized samples
+/// @param gain_db Optional amount of gain (in dB) to apply when converting. There is no verification for clipping.
+void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint32_t num_samples, uint8_t input_bits,
+                        float gain_db);
+
+/// @brief Converts an array of floating point samples into quantized samples with the specified number of bits.
+/// @param input_buffer Pointer to the input floating point samples
+/// @param output_buffer Pointer to the output quantized samples. Samples will be aligned to the byte.
+/// @param num_samples Number of samples to convert
+/// @param output_bits Number of bits per sample for the quantized samples
+/// @return Number of clipped samples
+uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, uint32_t num_samples, uint8_t output_bits);

--- a/src/resample/resampler.cpp
+++ b/src/resample/resampler.cpp
@@ -1,4 +1,5 @@
 #include "resampler.h"
+#include "utils.h"
 
 namespace resampler {
 
@@ -15,12 +16,12 @@ Resampler::~Resampler() {
   }
 };
 
-bool Resampler::initialize(float target_sample_rate, float source_sample_rate, uint8_t channels,
-                           uint16_t number_of_taps, uint16_t number_of_filters, bool use_pre_post_filter,
-                           bool subsample_interpolate) {
-  this->channels_ = channels;
-  this->number_of_taps_ = number_of_taps;
-  this->number_of_filters_ = number_of_filters;
+bool Resampler::initialize(ResamplerConfiguration &config) {
+  this->input_bits_ = config.source_bits_per_sample;
+  this->output_bits_ = config.target_bits_per_sample;
+  this->channels_ = config.channels;
+  this->number_of_taps_ = config.number_of_taps;
+  this->number_of_filters_ = config.number_of_filters;
 
   this->float_input_buffer_ =
       (float *) heap_caps_malloc(this->input_buffer_samples_ * sizeof(float), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
@@ -32,102 +33,119 @@ bool Resampler::initialize(float target_sample_rate, float source_sample_rate, u
     return false;
   }
 
-  int flags = 0;
+  if (config.source_sample_rate != config.target_sample_rate) {
+    this->requires_resampling_ = true;
+    int flags = 0;
 
-  if (subsample_interpolate) {
-    flags |= SUBSAMPLE_INTERPOLATE;
-  }
-
-  this->sample_ratio_ = target_sample_rate / source_sample_rate;
-
-  if (this->sample_ratio_ < 1.0) {
-    this->lowpass_ratio_ -= (10.24 / this->number_of_taps_);
-
-    if (this->lowpass_ratio_ < 0.84) {
-      this->lowpass_ratio_ = 0.84;
+    if (config.subsample_interpolate) {
+      flags |= SUBSAMPLE_INTERPOLATE;
     }
 
-    if (this->lowpass_ratio_ < this->sample_ratio_) {
-      // avoid discontinuities near unity sample ratios
-      this->lowpass_ratio_ = this->sample_ratio_;
+    this->sample_ratio_ = config.target_sample_rate / config.source_sample_rate;
+
+    if (this->sample_ratio_ < 1.0) {
+      this->lowpass_ratio_ -= (10.24 / this->number_of_taps_);
+
+      if (this->lowpass_ratio_ < 0.84) {
+        this->lowpass_ratio_ = 0.84;
+      }
+
+      if (this->lowpass_ratio_ < this->sample_ratio_) {
+        // avoid discontinuities near unity sample ratios
+        this->lowpass_ratio_ = this->sample_ratio_;
+      }
     }
-  }
-  if (this->lowpass_ratio_ * this->sample_ratio_ < 0.98 && use_pre_post_filter) {
-    float cutoff = this->lowpass_ratio_ * this->sample_ratio_ / 2.0;
-    biquad_lowpass(&this->lowpass_coeff_, cutoff);
-    this->pre_filter_ = true;
-  }
-
-  if (this->lowpass_ratio_ / this->sample_ratio_ < 0.98 && use_pre_post_filter && !this->pre_filter_) {
-    float cutoff = this->lowpass_ratio_ / this->sample_ratio_ / 2.0;
-    biquad_lowpass(&this->lowpass_coeff_, cutoff);
-    this->post_filter_ = true;
-  }
-
-  if (this->pre_filter_ || this->post_filter_) {
-    for (int i = 0; i < this->channels_; ++i) {
-      biquad_init(&this->lowpass_[i][0], &this->lowpass_coeff_, 1.0);
-      biquad_init(&this->lowpass_[i][1], &this->lowpass_coeff_, 1.0);
+    if (this->lowpass_ratio_ * this->sample_ratio_ < 0.98 && config.use_pre_or_post_filter) {
+      float cutoff = this->lowpass_ratio_ * this->sample_ratio_ / 2.0;
+      biquad_lowpass(&this->lowpass_coeff_, cutoff);
+      this->pre_filter_ = true;
     }
-  }
 
-  if (this->sample_ratio_ < 1.0) {
-    this->resampler_ = resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
-                                    this->sample_ratio_ * this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
-  } else if (this->lowpass_ratio_ < 1.0) {
-    this->resampler_ = resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
-                                    this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
-  } else {
-    this->resampler_ = resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_, 1.0, flags);
-  }
+    if (this->lowpass_ratio_ / this->sample_ratio_ < 0.98 && config.use_pre_or_post_filter && !this->pre_filter_) {
+      float cutoff = this->lowpass_ratio_ / this->sample_ratio_ / 2.0;
+      biquad_lowpass(&this->lowpass_coeff_, cutoff);
+      this->post_filter_ = true;
+    }
 
-  resampleAdvancePosition(this->resampler_, this->number_of_taps_ / 2.0);
+    if (this->pre_filter_ || this->post_filter_) {
+      for (int i = 0; i < this->channels_; ++i) {
+        biquad_init(&this->lowpass_[i][0], &this->lowpass_coeff_, 1.0);
+        biquad_init(&this->lowpass_[i][1], &this->lowpass_coeff_, 1.0);
+      }
+    }
+
+    if (this->sample_ratio_ < 1.0) {
+      this->resampler_ = resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
+                                      this->sample_ratio_ * this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
+    } else if (this->lowpass_ratio_ < 1.0) {
+      this->resampler_ = resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
+                                      this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
+    } else {
+      this->resampler_ = resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_, 1.0, flags);
+    }
+
+    resampleAdvancePosition(this->resampler_, this->number_of_taps_ / 2.0);
+  }
 
   return true;
 }
 
-void Resampler::resample(const int16_t *input, int16_t *output, size_t input_frames_available,
-                         size_t output_frames_free, size_t &frames_used, size_t &frames_generated) {
-  unsigned int necessary_frames = resampleGetRequiredSamples(this->resampler_, output_frames_free, this->sample_ratio_);
+ResamplerResults Resampler::resample(const uint8_t *input_buffer, uint8_t *output_buffer, size_t input_frames_available,
+                                     size_t output_frames_free, float gain_db) {
+  size_t frames_to_process = input_frames_available;
 
-  unsigned int frames_to_process = std::min(input_frames_available, necessary_frames);
-
-  for (unsigned int i = 0; i < frames_to_process * this->channels_; ++i) {
-    this->float_input_buffer_[i] = static_cast<float>(input[i]) / 32768.0f;
+  if (this->requires_resampling_) {
+    const size_t necessary_frames =
+        resampleGetRequiredSamples(this->resampler_, output_frames_free, this->sample_ratio_);
+    frames_to_process = std::min(frames_to_process, necessary_frames);
+  } else {
+    frames_to_process = std::min(frames_to_process, output_frames_free);
+  }
+  uint32_t conversion_time = 0;
+  if (this->requires_resampling_) {
+    quantized_to_float(input_buffer, this->float_input_buffer_, frames_to_process * this->channels_, this->input_bits_,
+                       gain_db);
+  } else {
+    // Just converting the bits per sample
+    quantized_to_float(input_buffer, this->float_output_buffer_, frames_to_process * this->channels_, this->input_bits_,
+                       gain_db);
   }
 
-  if (this->pre_filter_) {
-    for (int i = 0; i < this->channels_; ++i) {
-      biquad_apply_buffer(&this->lowpass_[i][0], this->float_input_buffer_ + i, frames_to_process, this->channels_);
-      biquad_apply_buffer(&this->lowpass_[i][1], this->float_input_buffer_ + i, frames_to_process, this->channels_);
+  size_t frames_used = frames_to_process;
+  size_t frames_generated = frames_to_process;
+  size_t predicted_frames_used = frames_to_process;
+
+  if (this->requires_resampling_) {
+    if (this->pre_filter_) {
+      for (int i = 0; i < this->channels_; ++i) {
+        biquad_apply_buffer(&this->lowpass_[i][0], this->float_input_buffer_ + i, frames_to_process, this->channels_);
+        biquad_apply_buffer(&this->lowpass_[i][1], this->float_input_buffer_ + i, frames_to_process, this->channels_);
+      }
+    }
+
+    ResampleResult res =
+        resampleProcessInterleaved(this->resampler_, this->float_input_buffer_, frames_to_process,
+                                   this->float_output_buffer_, output_frames_free, this->sample_ratio_);
+
+    frames_used = res.input_used;
+    frames_generated = res.output_generated;
+
+    if (this->post_filter_) {
+      for (int i = 0; i < this->channels_; ++i) {
+        biquad_apply_buffer(&this->lowpass_[i][0], this->float_output_buffer_ + i, frames_generated, this->channels_);
+        biquad_apply_buffer(&this->lowpass_[i][1], this->float_output_buffer_ + i, frames_generated, this->channels_);
+      }
     }
   }
 
-  ResampleResult res = resampleProcessInterleaved(this->resampler_, this->float_input_buffer_, frames_to_process,
-                                                  this->float_output_buffer_, output_frames_free, this->sample_ratio_);
+  uint32_t clipped_samples = float_to_quantized(this->float_output_buffer_, output_buffer,
+                                                frames_generated * this->channels_, this->output_bits_);
 
-  frames_generated = res.output_generated;
-
-  if (this->post_filter_) {
-    for (int i = 0; i < this->channels_; ++i) {
-      biquad_apply_buffer(&this->lowpass_[i][0], this->float_output_buffer_ + i, frames_generated, this->channels_);
-      biquad_apply_buffer(&this->lowpass_[i][1], this->float_output_buffer_ + i, frames_generated, this->channels_);
-    }
-  }
-
-  frames_used = res.input_used;
-
-  const size_t samples_generated = frames_generated * this->channels_;
-  for (size_t i = 0; i < samples_generated; ++i) {
-    const float sample = this->float_output_buffer_[i];
-    if (sample >= 1.0f) {
-      output[i] = 32767;
-    } else if (sample < -1.0f) {
-      output[i] = -32768;
-    } else {
-      output[i] = static_cast<int16_t>(sample * 32768);
-    }
-  }
+  ResamplerResults results = {.frames_used = frames_used,
+                              .frames_generated = frames_generated,
+                              .predicted_frames_used = frames_to_process,
+                              .clipped_samples = clipped_samples};
+  return results;
 }
 
 }  // namespace resampler

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,91 @@
+#include "utils.h"
+
+void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint32_t num_samples, uint8_t input_bits,
+                        float gain_db) {
+  float gain = pow(10.0, gain_db / 20.0);
+
+  if (input_bits <= 8) {
+    float gain_factor = gain / 128.0;
+
+    for (unsigned int i = 0; i < num_samples; ++i) {
+      output_buffer[i] = ((int) input_buffer[i] - 128) * gain_factor;
+    }
+
+  } else if (input_bits <= 16) {
+    float gain_factor = gain / 32768.0;
+    unsigned int i, j;
+
+    for (i = j = 0; i < num_samples; ++i) {
+      int16_t value = input_buffer[j++];
+      value += input_buffer[j++] << 8;
+      output_buffer[i] = value * gain_factor;
+    }
+  } else if (input_bits <= 24) {
+    float gain_factor = gain / 8388608.0;
+    unsigned int i, j;
+
+    for (i = j = 0; i < num_samples; ++i) {
+      int32_t value = input_buffer[j++];
+      value += input_buffer[j++] << 8;
+      value += (int32_t) (signed char) input_buffer[j++] << 16;
+      output_buffer[i] = value * gain_factor;
+    }
+  } else if (input_bits <= 32) {
+    float gain_factor = gain / 2147483648.0;
+    unsigned int i, j;
+
+    for (i = j = 0; i < num_samples; ++i) {
+      int32_t value = input_buffer[j++];
+      value += input_buffer[j++] << 8;
+      value += (int32_t) (signed char) input_buffer[j++] << 16;
+      value += (int32_t) (signed char) input_buffer[j++] << 24;
+      output_buffer[i] = value * gain_factor;
+    }
+  }
+}
+
+uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, uint32_t num_samples,
+                            uint8_t output_bits) {
+  float scalar = (static_cast<uint64_t>(1) << output_bits) / 2.0;
+  int32_t offset = (output_bits <= 8) * 128;
+  int32_t high_clip = (1 << (output_bits - 1)) - 1;
+  int32_t low_clip = ~high_clip;
+  int left_shift = (32 - output_bits) % 8;
+  size_t i, j;
+  uint32_t clipped_samples = 0;
+
+  for (i = j = 0; i < num_samples; ++i) {
+    int32_t output = floor((input_buffer[i] * scalar) + 0.5);
+    if (output_bits < 32) {
+      if (output > high_clip) {
+        ++clipped_samples;
+        output = high_clip;
+      } else if (output < low_clip) {
+        ++clipped_samples;
+        output = low_clip;
+      }
+    } else {
+      if (input_buffer[i] >= 1.0f) {
+        ++clipped_samples;
+        output = high_clip;
+      } else if (input_buffer[i] < -1.0f) {
+        ++clipped_samples;
+        output = low_clip;
+      }
+    }
+
+    output_buffer[j++] = output = (output << left_shift) + offset;
+    if (output_bits > 8) {
+      output_buffer[j++] = output >> 8;
+
+      if (output_bits > 16) {
+        output_buffer[j++] = output >> 16;
+      }
+      if (output_bits > 24) {
+        output_buffer[j++] = output >> 24;
+      }
+    }
+  }
+
+  return clipped_samples;
+}


### PR DESCRIPTION
- Uses a struct for initializing and returning the results on each resample call
- Supports arbitrary bits per sample for the input and output audio samples
  - Moves functions for converting to and from floating point samples to ``utils.cpp``