### PR TITLE
Ensure single precision floating point arithmetic and rename utils

### DIFF
--- a/include/quantization_utils.h
+++ b/include/quantization_utils.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 
 namespace esp_audio_libs {
+namespace quantization_utils {
 
 /// @brief Converts an array of quantized samples with the specified number of bits into floating point samples.
 /// @param input_buffer Pointer to the input quantized samples aligned to the byte
@@ -23,4 +24,5 @@ void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint3
 uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, uint32_t num_samples,
                             uint8_t output_bits);
 
+}  // namespace quantization_utils
 }  // namespace esp_audio_libs

--- a/src/quantization_utils.cpp
+++ b/src/quantization_utils.cpp
@@ -5,17 +5,17 @@ namespace quantization_utils {
 
 void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint32_t num_samples, uint8_t input_bits,
                         float gain_db) {
-  float gain = pow(10.0, gain_db / 20.0);
+  float gain = pow(10.0f, gain_db / 20.0f);
 
   if (input_bits <= 8) {
-    float gain_factor = gain / 128.0;
+    float gain_factor = gain / 128.0f;
 
     for (unsigned int i = 0; i < num_samples; ++i) {
       output_buffer[i] = ((int) input_buffer[i] - 128) * gain_factor;
     }
 
   } else if (input_bits <= 16) {
-    float gain_factor = gain / 32768.0;
+    float gain_factor = gain / 32768.0f;
     unsigned int i, j;
 
     for (i = j = 0; i < num_samples; ++i) {
@@ -24,7 +24,7 @@ void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint3
       output_buffer[i] = value * gain_factor;
     }
   } else if (input_bits <= 24) {
-    float gain_factor = gain / 8388608.0;
+    float gain_factor = gain / 8388608.0f;
     unsigned int i, j;
 
     for (i = j = 0; i < num_samples; ++i) {
@@ -34,7 +34,7 @@ void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint3
       output_buffer[i] = value * gain_factor;
     }
   } else if (input_bits <= 32) {
-    float gain_factor = gain / 2147483648.0;
+    float gain_factor = gain / 2147483648.0f;
     unsigned int i, j;
 
     for (i = j = 0; i < num_samples; ++i) {
@@ -49,7 +49,7 @@ void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint3
 
 uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, uint32_t num_samples,
                             uint8_t output_bits) {
-  float scalar = (static_cast<uint64_t>(1) << output_bits) / 2.0;
+  float scalar = (static_cast<uint64_t>(1) << output_bits) / 2.0f;
   int32_t offset = (output_bits <= 8) * 128;
   int32_t high_clip = (1 << (output_bits - 1)) - 1;
   int32_t low_clip = ~high_clip;
@@ -58,7 +58,7 @@ uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, u
   uint32_t clipped_samples = 0;
 
   for (i = j = 0; i < num_samples; ++i) {
-    int32_t output = floor((input_buffer[i] * scalar) + 0.5);
+    int32_t output = floor((input_buffer[i] * scalar) + 0.5f);
     if (output_bits < 32) {
       if (output > high_clip) {
         ++clipped_samples;

--- a/src/quantization_utils.cpp
+++ b/src/quantization_utils.cpp
@@ -1,6 +1,7 @@
-#include "utils.h"
+#include "quantization_utils.h"
 
 namespace esp_audio_libs {
+namespace quantization_utils {
 
 void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint32_t num_samples, uint8_t input_bits,
                         float gain_db) {
@@ -92,4 +93,5 @@ uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, u
   return clipped_samples;
 }
 
-}
+}  // namespace quantization_utils
+}  // namespace esp_audio_libs

--- a/src/quantization_utils.cpp
+++ b/src/quantization_utils.cpp
@@ -5,7 +5,7 @@ namespace quantization_utils {
 
 void quantized_to_float(const uint8_t *input_buffer, float *output_buffer, uint32_t num_samples, uint8_t input_bits,
                         float gain_db) {
-  float gain = pow(10.0f, gain_db / 20.0f);
+  float gain = powf(10.0f, gain_db / 20.0f);
 
   if (input_bits <= 8) {
     float gain_factor = gain / 128.0f;
@@ -58,7 +58,7 @@ uint32_t float_to_quantized(const float *input_buffer, uint8_t *output_buffer, u
   uint32_t clipped_samples = 0;
 
   for (i = j = 0; i < num_samples; ++i) {
-    int32_t output = floor((input_buffer[i] * scalar) + 0.5f);
+    int32_t output = floorf((input_buffer[i] * scalar) + 0.5f);
     if (output_bits < 32) {
       if (output > high_clip) {
         ++clipped_samples;

--- a/src/resample/resampler.cpp
+++ b/src/resample/resampler.cpp
@@ -1,5 +1,5 @@
 #include "resampler.h"
-#include "utils.h"
+#include "quantization_utils.h"
 
 namespace esp_audio_libs {
 namespace resampler {
@@ -44,11 +44,11 @@ bool Resampler::initialize(ResamplerConfiguration &config) {
 
     this->sample_ratio_ = config.target_sample_rate / config.source_sample_rate;
 
-    if (this->sample_ratio_ < 1.0) {
-      this->lowpass_ratio_ -= (10.24 / this->number_of_taps_);
+    if (this->sample_ratio_ < 1.0f) {
+      this->lowpass_ratio_ -= (10.24f / this->number_of_taps_);
 
-      if (this->lowpass_ratio_ < 0.84) {
-        this->lowpass_ratio_ = 0.84;
+      if (this->lowpass_ratio_ < 0.84f) {
+        this->lowpass_ratio_ = 0.84f;
       }
 
       if (this->lowpass_ratio_ < this->sample_ratio_) {
@@ -56,36 +56,36 @@ bool Resampler::initialize(ResamplerConfiguration &config) {
         this->lowpass_ratio_ = this->sample_ratio_;
       }
     }
-    if (this->lowpass_ratio_ * this->sample_ratio_ < 0.98 && config.use_pre_or_post_filter) {
-      float cutoff = this->lowpass_ratio_ * this->sample_ratio_ / 2.0;
+    if (this->lowpass_ratio_ * this->sample_ratio_ < 0.98f && config.use_pre_or_post_filter) {
+      float cutoff = this->lowpass_ratio_ * this->sample_ratio_ / 2.0f;
       art_resampler::biquad_lowpass(&this->lowpass_coeff_, cutoff);
       this->pre_filter_ = true;
     }
 
-    if (this->lowpass_ratio_ / this->sample_ratio_ < 0.98 && config.use_pre_or_post_filter && !this->pre_filter_) {
-      float cutoff = this->lowpass_ratio_ / this->sample_ratio_ / 2.0;
+    if (this->lowpass_ratio_ / this->sample_ratio_ < 0.98f && config.use_pre_or_post_filter && !this->pre_filter_) {
+      float cutoff = this->lowpass_ratio_ / this->sample_ratio_ / 2.0f;
       art_resampler::biquad_lowpass(&this->lowpass_coeff_, cutoff);
       this->post_filter_ = true;
     }
 
     if (this->pre_filter_ || this->post_filter_) {
       for (int i = 0; i < this->channels_; ++i) {
-        art_resampler::biquad_init(&this->lowpass_[i][0], &this->lowpass_coeff_, 1.0);
-        art_resampler::biquad_init(&this->lowpass_[i][1], &this->lowpass_coeff_, 1.0);
+        art_resampler::biquad_init(&this->lowpass_[i][0], &this->lowpass_coeff_, 1.0f);
+        art_resampler::biquad_init(&this->lowpass_[i][1], &this->lowpass_coeff_, 1.0f);
       }
     }
 
-    if (this->sample_ratio_ < 1.0) {
+    if (this->sample_ratio_ < 1.0f) {
       this->resampler_ = art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
                                       this->sample_ratio_ * this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
-    } else if (this->lowpass_ratio_ < 1.0) {
+    } else if (this->lowpass_ratio_ < 1.0f) {
       this->resampler_ = art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
                                       this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
     } else {
-      this->resampler_ = art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_, 1.0, flags);
+      this->resampler_ = art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_, 1.0f, flags);
     }
 
-    art_resampler::resampleAdvancePosition(this->resampler_, this->number_of_taps_ / 2.0);
+    art_resampler::resampleAdvancePosition(this->resampler_, this->number_of_taps_ / 2.0f);
   }
 
   return true;
@@ -104,11 +104,11 @@ ResamplerResults Resampler::resample(const uint8_t *input_buffer, uint8_t *outpu
   }
   uint32_t conversion_time = 0;
   if (this->requires_resampling_) {
-    quantized_to_float(input_buffer, this->float_input_buffer_, frames_to_process * this->channels_, this->input_bits_,
+    quantization_utils::quantized_to_float(input_buffer, this->float_input_buffer_, frames_to_process * this->channels_, this->input_bits_,
                        gain_db);
   } else {
     // Just converting the bits per sample
-    quantized_to_float(input_buffer, this->float_output_buffer_, frames_to_process * this->channels_, this->input_bits_,
+    quantization_utils::quantized_to_float(input_buffer, this->float_output_buffer_, frames_to_process * this->channels_, this->input_bits_,
                        gain_db);
   }
 
@@ -139,7 +139,7 @@ ResamplerResults Resampler::resample(const uint8_t *input_buffer, uint8_t *outpu
     }
   }
 
-  uint32_t clipped_samples = float_to_quantized(this->float_output_buffer_, output_buffer,
+  uint32_t clipped_samples = quantization_utils::float_to_quantized(this->float_output_buffer_, output_buffer,
                                                 frames_generated * this->channels_, this->output_bits_);
 
   ResamplerResults results = {.frames_used = frames_used,


### PR DESCRIPTION
Makes sure to use only single precision floating point arithmetic for speed, as double precision arithmetic is not hardware based on ESP32s.

Renames ``utils`` to ``quanitzation_utils`` and wraps it in a namespace.