### PR TITLE
Bugfix: Use internal memory for buffers if PSRAM allocation fails

### DIFF
--- a/src/decode/flac_decoder.cpp
+++ b/src/decode/flac_decoder.cpp
@@ -257,6 +257,10 @@ FLACDecoderResult FLACDecoder::decode_frame(uint8_t *buffer, size_t buffer_lengt
     // freed in free_buffers()
     this->block_samples_ = (int32_t *) heap_caps_malloc(this->max_block_size_ * this->num_channels_ * sizeof(int32_t),
                                                         MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (this->block_samples_ == nullptr) {
+      this->block_samples_ =
+          (int32_t *) heap_caps_malloc(this->max_block_size_ * this->num_channels_ * sizeof(int32_t), MALLOC_CAP_8BIT);
+    }
   }
   if (!this->block_samples_) {
     return FLAC_DECODER_ERROR_MEMORY_ALLOCATION_ERROR;

--- a/src/decode/mp3_decoder.cpp
+++ b/src/decode/mp3_decoder.cpp
@@ -8056,17 +8056,34 @@ MP3DecInfo *AllocateBuffers(void) {
   SubbandInfo *sbi;
 
   mp3DecInfo = (MP3DecInfo *) heap_caps_malloc(sizeof(MP3DecInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (mp3DecInfo == nullptr) {
+    mp3DecInfo = (MP3DecInfo *) malloc(sizeof(MP3DecInfo));
+  }
   if (!mp3DecInfo)
     return 0;
   ClearBuffer(mp3DecInfo, sizeof(MP3DecInfo));
 
-  fh = (FrameHeader *) heap_caps_malloc(sizeof(FrameHeader), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  si = (SideInfo *) heap_caps_malloc(sizeof(SideInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  sfi = (ScaleFactorInfo *) heap_caps_malloc(sizeof(ScaleFactorInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
   hi = (HuffmanInfo *) heap_caps_malloc(sizeof(HuffmanInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (hi == nullptr) {
+    hi = (HuffmanInfo *) malloc(sizeof(HuffmanInfo));
+  }
   di = (DequantInfo *) heap_caps_malloc(sizeof(DequantInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (di == nullptr) {
+    di = (DequantInfo *) malloc(sizeof(DequantInfo));
+  }
   mi = (IMDCTInfo *) heap_caps_malloc(sizeof(IMDCTInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (mi == nullptr) {
+    mi = (IMDCTInfo *) malloc(sizeof(IMDCTInfo));
+  }
   sbi = (SubbandInfo *) heap_caps_malloc(sizeof(SubbandInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (sbi == nullptr) {
+    sbi = (SubbandInfo *) malloc(sizeof(SubbandInfo));
+  }
+
+  // Relatively small structures, fine to leave in internal memory
+  fh = (FrameHeader *) malloc(sizeof(FrameHeader));
+  si = (SideInfo *) malloc(sizeof(SideInfo));
+  sfi = (ScaleFactorInfo *) malloc(sizeof(ScaleFactorInfo));
 
   mp3DecInfo->FrameHeaderPS = (void *) fh;
   mp3DecInfo->SideInfoPS = (void *) si;

--- a/src/resample/art_resampler.cpp
+++ b/src/resample/art_resampler.cpp
@@ -107,9 +107,22 @@ Resample *resampleInit(int numChannels, int numTaps, int numFilters, float lowpa
   cxt->filters = (float **) calloc(cxt->numFilters + 1, sizeof(float *));
 
   cxt->tempFilter = (float *) heap_caps_malloc(numTaps * sizeof(float), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (cxt->tempFilter == nullptr) {
+    cxt->tempFilter = (float *) malloc(numTaps * sizeof(float));
+  }
+
+  if (cxt->tempFilter == nullptr) {
+    return NULL;
+  }
 
   for (i = 0; i <= cxt->numFilters; ++i) {
     cxt->filters[i] = (float *) heap_caps_malloc(cxt->numTaps * sizeof(float), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (cxt->filters[i] == nullptr) {
+      cxt->filters[i] = (float *) malloc(cxt->numTaps * sizeof(float));
+    }
+    if (cxt->filters[i] == nullptr) {
+      return NULL;
+    }
     memset(cxt->filters[i], 0, cxt->numTaps * sizeof(float));
     init_filter(cxt, cxt->filters[i], (float) i / cxt->numFilters, lowpassRatio);
   }
@@ -120,6 +133,12 @@ Resample *resampleInit(int numChannels, int numTaps, int numFilters, float lowpa
 
   for (i = 0; i < numChannels; ++i) {
     cxt->buffers[i] = (float *) heap_caps_malloc(cxt->numSamples * sizeof(float), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (cxt->buffers[i] == nullptr) {
+      cxt->buffers[i] = (float *) malloc(cxt->numSamples * sizeof(float));
+    }
+    if (cxt->buffers[i] == nullptr) {
+      return NULL;
+    }
     memset(cxt->buffers[i], 0, cxt->numSamples * sizeof(float));
   }
 


### PR DESCRIPTION
Currently if the device has no PSRAM, the flac decoder, mp3 decoder, and resampler would fail as the buffers would fail to allocate. This PR attempts to allocate in internal memory if the PSRAM allocation fails. Additionally, it now properly reports if any of the resampler's buffers failed to allocate.