### PR TITLE
Bugfix: FLAC decoder should use 32 bit integer for coefficients

### DIFF
--- a/include/flac_decoder.h
+++ b/include/flac_decoder.h
@@ -41,7 +41,7 @@ enum FLACDecoderResult {
 };
 
 // Coefficients for fixed linear prediction
-const static std::vector<int16_t> FLAC_FIXED_COEFFICIENTS[] = {
+const static std::vector<int32_t> FLAC_FIXED_COEFFICIENTS[] = {
     {1}, {1, 1}, {-1, 2, 1}, {1, -3, 3, 1}, {-1, 4, -6, 4, 1}};
 
 /* Basic FLAC decoder ported from:
@@ -116,7 +116,7 @@ class FLACDecoder {
   FLACDecoderResult decode_residuals(int32_t *buffer, size_t warm_up_samples, uint32_t block_size);
 
   /* Completes predicted samples. */
-  void restore_linear_prediction(int32_t *sub_frame_buffer, size_t num_of_samples, const std::vector<int16_t> &coefs,
+  void restore_linear_prediction(int32_t *sub_frame_buffer, size_t num_of_samples, const std::vector<int32_t> &coefs,
                                  int32_t shift);
 
   uint32_t read_aligned_byte();

--- a/src/decode/flac_decoder.cpp
+++ b/src/decode/flac_decoder.cpp
@@ -455,7 +455,7 @@ FLACDecoderResult FLACDecoder::decode_lpc_subframe(uint32_t block_size, std::siz
   uint32_t precision = this->read_uint(4) + 1;
   int32_t shift = this->read_sint(5);
 
-  std::vector<int16_t> coefs;
+  std::vector<int32_t> coefs;
   coefs.resize(lpc_order + 1);
   for (std::size_t i = 0; i < lpc_order; i++) {
     coefs[lpc_order - i - 1] = this->read_sint(precision);
@@ -536,7 +536,7 @@ FLACDecoderResult FLACDecoder::decode_residuals(int32_t *sub_frame_buffer, size_
 }  // decode_residuals
 
 void FLACDecoder::restore_linear_prediction(int32_t *sub_frame_buffer, size_t num_of_samples,
-                                            const std::vector<int16_t> &coefs, int32_t shift) {
+                                            const std::vector<int32_t> &coefs, int32_t shift) {
   for (std::size_t i = 0; i < num_of_samples - coefs.size() + 1; i++) {
     int32_t sum = 0;
     for (std::size_t j = 0; j < coefs.size(); ++j) {


### PR DESCRIPTION
The FLAC decoder could potentially have audible artifacts depending on the media and the compression level, since the linear predictions were stored at 16 bit integers. This fixes it by using 32 bit precision, matching the format specification.