### PR TITLE
Speed improvement - Build with O2 optimizations

### DIFF
--- a/library.json
+++ b/library.json
@@ -18,5 +18,10 @@
     "homepage": "https://github.com/esphome/esp-audio-libs.git",
     "dependencies": [],
     "frameworks": "*",
-    "platforms": "espressif32"
+    "platforms": "espressif32",
+    "build": {
+      "flags": [
+        "-O2"
+      ]
+    }
   }


### PR DESCRIPTION
Builds the audio libraries with the O2 compiler flag set. On an ESP32-S3, this speeds up the FLAC decoder by about 20%. For MP3s, it effectively makes no difference, as its a very small speed increase of only 1%. It does increase the firmware size by ~4kB, but the speed up is worth the small size increase.