### PR TITLE
Generalize memory allocation and fix CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,34 +1,68 @@
 cmake_minimum_required(VERSION 3.15)
 
+# Common source files
 set(srcs
   src/decode/flac_decoder.cpp
   src/decode/mp3_decoder.cpp
   src/decode/wav_decoder.cpp
-  src/dsp/dsps_add_s16_as32.S
-  src/dsp/dsps_add_s16_aes3.S
-  src/dsp/dsps_add_s15_ansi.c
-  src/dsp/dsps_biquad_f32_ae32.S
-  src/dsp/dsps_biquad_f32_aes3.S
+  src/dsp/dsps_add_s16_ansi.c
   src/dsp/dsps_biquad_f32_ansi.c
-  src/dsp/dsps_dotprod_f32_ae32.S
-  src/dsp/dsps_dotprod_f32_aes3.S
   src/dsp/dsps_dotprod_f32_ansi.c
-  src/dsp/dsps_dotprod_f32_m_ae32.S
-  src/dsp/dsps_mulc_s16_ae32.S
   src/dsp/dsps_mulc_s16_ansi.c
   src/resample/art_biquad.cpp
   src/resample/art_resampler.cpp
   src/resample/resampler.cpp
   src/quantization_utils.cpp
+  src/memory_utils.cpp
   )
 
 if(ESP_PLATFORM)
+  # Add ESP32-specific assembly optimizations
+  list(APPEND srcs
+    src/dsp/dsps_add_s16_ae32.S
+    src/dsp/dsps_add_s16_aes3.S
+    src/dsp/dsps_biquad_f32_ae32.S
+    src/dsp/dsps_biquad_f32_aes3.S
+    src/dsp/dsps_dotprod_f32_ae32.S
+    src/dsp/dsps_dotprod_f32_aes3.S
+    src/dsp/dsps_dotprod_f32_m_ae32.S
+    src/dsp/dsps_mulc_s16_ae32.S
+  )
+  
   # Build as an ESP-IDF component
   idf_component_register(
     SRCS ${srcs}
     INCLUDE_DIRS "include"
   )
+  
+  # Apply -O2 optimization for ESP-IDF builds
+  target_compile_options(${COMPONENT_LIB} PRIVATE -O2)
+  
   return()
 endif()
 
 project(esp-audio-libs VERSION 1.1.5)
+
+# Standalone build configuration
+add_library(esp-audio-libs STATIC ${srcs})
+
+target_include_directories(esp-audio-libs PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+# Set C++ standard
+target_compile_features(esp-audio-libs PUBLIC cxx_std_11)
+
+# Add compile options
+target_compile_options(esp-audio-libs PRIVATE -O2)
+
+# Installation rules
+install(TARGETS esp-audio-libs
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)

--- a/include/dsp.h
+++ b/include/dsp.h
@@ -16,8 +16,16 @@
 #define _DSP_H_
 
 #include "dsp_platform.h"
+#include <stdint.h>
 
+#ifdef ESP_PLATFORM
 #include <esp_err.h>
+#else
+// Define ESP error codes for non-ESP platforms
+typedef int esp_err_t;
+#define ESP_OK 0
+#define ESP_FAIL -1
+#endif
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/dsp_platform.h
+++ b/include/dsp_platform.h
@@ -1,7 +1,9 @@
 #ifndef _dsp_platform_H_
 #define _dsp_platform_H_
 
+#ifdef ESP_PLATFORM
 #include "sdkconfig.h"
+#endif
 
 #ifdef __XTENSA__
 #include <xtensa/config/core-isa.h>

--- a/include/resampler.h
+++ b/include/resampler.h
@@ -6,7 +6,6 @@
 #include "art_resampler.h"
 
 #include <algorithm>
-#include <esp_heap_caps.h>
 
 namespace esp_audio_libs {
 namespace resampler {

--- a/src/decode/mp3_decoder.cpp
+++ b/src/decode/mp3_decoder.cpp
@@ -41,8 +41,7 @@
  **************************************************************************************/
 
 #include "mp3_decoder.h"
-
-#include <esp_heap_caps.h>
+#include "../memory_utils.h"
 
 namespace esp_audio_libs {
 namespace helix_decoder {
@@ -8055,30 +8054,15 @@ MP3DecInfo *AllocateBuffers(void) {
   IMDCTInfo *mi;
   SubbandInfo *sbi;
 
-  mp3DecInfo = (MP3DecInfo *) heap_caps_malloc(sizeof(MP3DecInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (mp3DecInfo == nullptr) {
-    mp3DecInfo = (MP3DecInfo *) malloc(sizeof(MP3DecInfo));
-  }
+  mp3DecInfo = (MP3DecInfo *) internal::alloc_psram_fallback(sizeof(MP3DecInfo));
   if (!mp3DecInfo)
     return 0;
   ClearBuffer(mp3DecInfo, sizeof(MP3DecInfo));
 
-  hi = (HuffmanInfo *) heap_caps_malloc(sizeof(HuffmanInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (hi == nullptr) {
-    hi = (HuffmanInfo *) malloc(sizeof(HuffmanInfo));
-  }
-  di = (DequantInfo *) heap_caps_malloc(sizeof(DequantInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (di == nullptr) {
-    di = (DequantInfo *) malloc(sizeof(DequantInfo));
-  }
-  mi = (IMDCTInfo *) heap_caps_malloc(sizeof(IMDCTInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (mi == nullptr) {
-    mi = (IMDCTInfo *) malloc(sizeof(IMDCTInfo));
-  }
-  sbi = (SubbandInfo *) heap_caps_malloc(sizeof(SubbandInfo), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (sbi == nullptr) {
-    sbi = (SubbandInfo *) malloc(sizeof(SubbandInfo));
-  }
+  hi = (HuffmanInfo *) internal::alloc_psram_fallback(sizeof(HuffmanInfo));
+  di = (DequantInfo *) internal::alloc_psram_fallback(sizeof(DequantInfo));
+  mi = (IMDCTInfo *) internal::alloc_psram_fallback(sizeof(IMDCTInfo));
+  sbi = (SubbandInfo *) internal::alloc_psram_fallback(sizeof(SubbandInfo));
 
   // Relatively small structures, fine to leave in internal memory
   fh = (FrameHeader *) malloc(sizeof(FrameHeader));
@@ -8115,7 +8099,7 @@ MP3DecInfo *AllocateBuffers(void) {
 #define SAFE_FREE(x) \
   { \
     if (x) \
-      free(x); \
+      internal::free_psram_fallback(x); \
     (x) = 0; \
   } /* helper macro */
 

--- a/src/dsp/dsps_add_s16_ansi.c
+++ b/src/dsp/dsps_add_s16_ansi.c
@@ -5,17 +5,18 @@
  */
 
 #include "dsp.h"
+#include <stddef.h>
 
 esp_err_t dsps_add_s16_ansi(const int16_t *input1, const int16_t *input2, int16_t *output, int len, int step1,
                             int step2, int step_out, int shift) {
   if (NULL == input1) {
-    return ESP_ERR_INVALID_ARG;
+    return ESP_FAIL;
   }
   if (NULL == input2) {
-    return ESP_ERR_INVALID_ARG;
+    return ESP_FAIL;
   }
   if (NULL == output) {
-    return ESP_ERR_INVALID_ARG;
+    return ESP_FAIL;
   }
 
   for (int i = 0; i < len; i++) {

--- a/src/dsp/dsps_mulc_s16_ansi.c
+++ b/src/dsp/dsps_mulc_s16_ansi.c
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 #include "dsp.h"
+#include <stddef.h>
 
 esp_err_t dsps_mulc_s16_ansi(const int16_t *input, int16_t *output, int len, int16_t C, int step_in, int step_out) {
   if (NULL == input) {
-    return ESP_ERR_INVALID_ARG;
+    return ESP_FAIL;
   }
   if (NULL == output) {
-    return ESP_ERR_INVALID_ARG;
+    return ESP_FAIL;
   }
 
   for (int i = 0; i < len; i++) {

--- a/src/memory_utils.cpp
+++ b/src/memory_utils.cpp
@@ -1,0 +1,35 @@
+#include "memory_utils.h"
+#include <stdlib.h>
+
+#ifdef ESP_PLATFORM
+#include <esp_heap_caps.h>
+#endif
+
+namespace esp_audio_libs {
+namespace internal {
+
+void* alloc_psram_fallback(size_t size) {
+#ifdef ESP_PLATFORM
+    // Try to allocate from PSRAM first
+    void* ptr = heap_caps_malloc(size, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (ptr == nullptr) {
+        // Fall back to internal memory
+        ptr = heap_caps_malloc(size, MALLOC_CAP_8BIT);
+    }
+    return ptr;
+#else
+    // For non-ESP platforms, use standard malloc
+    return malloc(size);
+#endif
+}
+
+void free_psram_fallback(void* ptr) {
+#ifdef ESP_PLATFORM
+    heap_caps_free(ptr);
+#else
+    free(ptr);
+#endif
+}
+
+}  // namespace internal
+}  // namespace esp_audio_libs

--- a/src/memory_utils.h
+++ b/src/memory_utils.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stddef.h>
+
+namespace esp_audio_libs {
+namespace internal {
+
+/**
+ * @brief Allocate memory preferring PSRAM, falling back to internal memory
+ * 
+ * This function first attempts to allocate memory from PSRAM. If that fails,
+ * it falls back to allocating from internal memory.
+ * 
+ * @param size Size in bytes to allocate
+ * @return Pointer to allocated memory, or nullptr if allocation fails
+ */
+void* alloc_psram_fallback(size_t size);
+
+/**
+ * @brief Free memory allocated by alloc_psram_fallback
+ * 
+ * @param ptr Pointer to memory to free
+ */
+void free_psram_fallback(void* ptr);
+
+}  // namespace internal
+}  // namespace esp_audio_libs

--- a/src/resample/resampler.cpp
+++ b/src/resample/resampler.cpp
@@ -1,5 +1,6 @@
 #include "resampler.h"
 #include "quantization_utils.h"
+#include "../memory_utils.h"
 
 namespace esp_audio_libs {
 namespace resampler {
@@ -10,10 +11,10 @@ Resampler::~Resampler() {
   }
 
   if (this->float_input_buffer_ != nullptr) {
-    free(this->float_input_buffer_);
+    internal::free_psram_fallback(this->float_input_buffer_);
   }
   if (this->float_output_buffer_ != nullptr) {
-    free(this->float_output_buffer_);
+    internal::free_psram_fallback(this->float_output_buffer_);
   }
 };
 
@@ -25,16 +26,10 @@ bool Resampler::initialize(ResamplerConfiguration &config) {
   this->number_of_filters_ = config.number_of_filters;
 
   this->float_input_buffer_ =
-      (float *) heap_caps_malloc(this->input_buffer_samples_ * sizeof(float), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (this->float_input_buffer_ == nullptr) {
-    this->float_input_buffer_ = (float *) malloc(this->input_buffer_samples_ * sizeof(float));
-  }
+      (float *) internal::alloc_psram_fallback(this->input_buffer_samples_ * sizeof(float));
 
   this->float_output_buffer_ =
-      (float *) heap_caps_malloc(this->output_buffer_samples_ * sizeof(float), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
-  if (this->float_output_buffer_ == nullptr) {
-    this->float_output_buffer_ = (float *) malloc(this->output_buffer_samples_ * sizeof(float));
-  }
+      (float *) internal::alloc_psram_fallback(this->output_buffer_samples_ * sizeof(float));
 
   if ((this->float_input_buffer_ == nullptr) || (this->float_output_buffer_ == nullptr)) {
     return false;


### PR DESCRIPTION
Whenever we allocate heap memory, we try to first allocate in PSRAM and then fall back into internal memory. This PR centralizes that pattern into some helper functions in memory_utils. This also makes it easier to build on a PC for easier testing.

Updates the CMakeLists.txt file (which is when added as an IDF component) to:
 - Fix misspelled filenames
 - Compile with O2 optimizations (which the PlatformIO library already does)
 - Allows the library to be built on a computer for easier testing