### PR TITLE
Wrap assembly within an #if statement to avoid compilation errors

### DIFF
--- a/src/decode/flac/flac_lpc_32_asm.S
+++ b/src/decode/flac/flac_lpc_32_asm.S
@@ -18,6 +18,9 @@
  * - Generic fallback for orders > 12
  */
 
+#include "dsp_platform.h"
+#if (flac_lpc_asm_enabled == 1)
+
 .section .text
 .global restore_linear_prediction_32bit_asm
 .type restore_linear_prediction_32bit_asm, @function
@@ -904,3 +907,4 @@ restore_linear_prediction_32bit_asm:
     movi a2, 0                      // Return success
     retw.n
 
+#endif  // flac_lpc_asm_enabled

--- a/src/decode/flac/flac_lpc_32_asm.S
+++ b/src/decode/flac/flac_lpc_32_asm.S
@@ -18,7 +18,7 @@
  * - Generic fallback for orders > 12
  */
 
-#include "dsp_platform.h"
+#include "flac_lpc_platform.h"
 #if (flac_lpc_asm_enabled == 1)
 
 .section .text

--- a/src/decode/flac/flac_lpc_64_asm.S
+++ b/src/decode/flac/flac_lpc_64_asm.S
@@ -20,7 +20,7 @@
  * - Efficient 64-bit shifting using SRC instruction
  */
 
-#include "dsp_platform.h"
+#include "flac_lpc_platform.h"
 #if (flac_lpc_asm_enabled == 1)
 
 .section .text

--- a/src/decode/flac/flac_lpc_64_asm.S
+++ b/src/decode/flac/flac_lpc_64_asm.S
@@ -20,6 +20,9 @@
  * - Efficient 64-bit shifting using SRC instruction
  */
 
+#include "dsp_platform.h"
+#if (flac_lpc_asm_enabled == 1)
+
 .section .text
 .global restore_linear_prediction_64bit_asm
 .type restore_linear_prediction_64bit_asm, @function
@@ -1454,3 +1457,4 @@ restore_linear_prediction_64bit_asm:
     movi a2, 0                     // Return success
     retw.n
 
+#endif  // flac_lpc_asm_enabled


### PR DESCRIPTION
Guards against attempting to compile the Xtensa assembly on unsupported platforms.