### PR TITLE
Remove espressif registry api_token from publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,4 +35,3 @@ jobs:
           components: |
             esp-audio-libs: .
           namespace: esphome
-          api_token: ${{ secrets.IDF_COMPONENT_API_TOKEN }}


### PR DESCRIPTION
The gh action now supports OIDC for trusted publishing. I have set it to trust this repository in the new `esphome-libs` organisation.

https://github.com/espressif/upload-components-ci-action#1-oidc-authentication-recommended