### PR TITLE
Make FLAC decoder input pointers const-correct

### DIFF
--- a/include/flac_decoder.h
+++ b/include/flac_decoder.h
@@ -209,7 +209,7 @@ class FLACDecoder {
   /// @return FLAC_DECODER_SUCCESS when header is complete
   ///         FLAC_DECODER_HEADER_OUT_OF_DATA when more data is needed (streaming)
   ///         Error code on failure
-  FLACDecoderResult read_header(uint8_t *buffer, size_t buffer_length);
+  FLACDecoderResult read_header(const uint8_t *buffer, size_t buffer_length);
 
   /// @brief Decode a single FLAC frame into PCM samples
   ///
@@ -223,7 +223,7 @@ class FLACDecoder {
   /// @return FLAC_DECODER_SUCCESS on success
   ///         FLAC_DECODER_NO_MORE_FRAMES when end of stream reached
   ///         Error code on failure
-  FLACDecoderResult decode_frame(uint8_t *buffer, size_t buffer_length, uint8_t *output_buffer, uint32_t *num_samples);
+  FLACDecoderResult decode_frame(const uint8_t *buffer, size_t buffer_length, uint8_t *output_buffer, uint32_t *num_samples);
 
   // ========================================
   // Stream Information Getters
@@ -409,7 +409,7 @@ class FLACDecoder {
   // ========================================
   // Input Buffer State
   // ========================================
-  uint8_t *buffer_ = nullptr;          // Pointer to current input buffer
+  const uint8_t *buffer_ = nullptr;    // Pointer to current input buffer
   std::size_t buffer_index_ = 0;       // Current position in input buffer
   std::size_t bytes_left_ = 0;         // Bytes remaining in input buffer
   std::size_t frame_start_index_ = 0;  // Start position of current frame (for CRC)

--- a/src/decode/flac/flac_decoder.cpp
+++ b/src/decode/flac/flac_decoder.cpp
@@ -32,7 +32,7 @@ static const std::vector<int32_t> FIXED_COEFFICIENTS[] = {{}, {1}, {-1, 2}, {1, 
 // Header Parsing
 // ============================================================================
 
-FLACDecoderResult FLACDecoder::read_header(uint8_t *buffer, size_t buffer_length) {
+FLACDecoderResult FLACDecoder::read_header(const uint8_t *buffer, size_t buffer_length) {
   this->buffer_ = buffer;
   this->buffer_index_ = 0;
   this->bytes_left_ = buffer_length;
@@ -182,7 +182,7 @@ FLACDecoderResult FLACDecoder::read_header(uint8_t *buffer, size_t buffer_length
 // Force O3 optimization for decode_frame (performance critical)
 // This ensures PlatformIO builds also get optimal performance
 FLAC_OPTIMIZE_O3
-FLACDecoderResult FLACDecoder::decode_frame(uint8_t *buffer, size_t buffer_length, uint8_t *output_buffer,
+FLACDecoderResult FLACDecoder::decode_frame(const uint8_t *buffer, size_t buffer_length, uint8_t *output_buffer,
                                             uint32_t *num_samples) {
   this->buffer_ = buffer;
   this->buffer_index_ = 0;
@@ -955,7 +955,8 @@ void FLACDecoder::align_to_byte() {
 
 inline bool FLACDecoder::refill_bit_buffer() {
   if (this->bytes_left_ >= 4) {
-    const uint32_t new_word = *reinterpret_cast<uint32_t *>(&this->buffer_[this->buffer_index_]);
+    uint32_t new_word;
+    std::memcpy(&new_word, &this->buffer_[this->buffer_index_], sizeof(uint32_t));
     this->bit_buffer_ = __builtin_bswap32(new_word);
     this->bit_buffer_length_ = 32;
     this->buffer_index_ += 4;


### PR DESCRIPTION
Update FLAC decoder API to use const uint8_t* for input buffers, making it explicit that input data is not modified.

Changes:
- read_header() and decode_frame() now take const uint8_t* buffers
- Internal buffer_ member is now const-qualified
- Replaced unsafe reinterpret_cast with std::memcpy in refill_bit_buffer() for proper const-correctness and strict aliasing compliance