### PR TITLE
Add missing stdint.h include to mp3_decoder.h

### DIFF
--- a/include/mp3_decoder.h
+++ b/include/mp3_decoder.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef __XTENSA__


### PR DESCRIPTION
ESP-IDF 6.0 ships GCC 15 and switches the default C library from Newlib to Picolibc. With Picolibc, `uint32_t` is no longer pulled in transitively through other headers.

This adds `#include <stdint.h>` to `mp3_decoder.h` which uses `uint32_t` (e.g. `imdctWin`, `csa`, `polyCoef` externs) but was missing the include. Other headers in the library (`flac_decoder.h`, `wav_decoder.h`, `dsp.h`, `quantization_utils.h`) already include it.