### PR TITLE
Add general mixing helper functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(srcs
   src/memory_utils.cpp
   src/gain.cpp
   src/ducking.cpp
+  src/pcm_convert.cpp
   )
 
 if(ESP_PLATFORM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(srcs
   src/quantization_utils.cpp
   src/memory_utils.cpp
   src/gain.cpp
+  src/ducking.cpp
   )
 
 if(ESP_PLATFORM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(srcs
   src/memory_utils.cpp
   src/gain.cpp
   src/ducking.cpp
+  src/mixer.cpp
   src/pcm_convert.cpp
   )
 

--- a/include/ducking.h
+++ b/include/ducking.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace esp_audio_libs {
+namespace ducking {
+
+/// @brief Largest dB reduction supported by set_target(). Larger requests are clamped here.
+constexpr uint8_t MAX_DB_REDUCTION = 50;
+
+/// @brief Mutable ducking state for one audio stream.
+///
+/// Create one per stream, zero-initialized (the defaults below mean "not ducked, no transition").
+/// Call set_target() to schedule a level change, then apply() on each block of samples.
+struct DuckingState {
+  // Current attenuation in dB. While a transition is in progress this steps toward the target.
+  int8_t current_db_reduction{0};
+  // The level set_target() is moving toward. Equal to current_db_reduction when settled.
+  uint8_t target_db_reduction{0};
+  // Samples left in the active transition. 0 means no transition is in progress.
+  uint32_t transition_samples_remaining{0};
+  // Samples between successive 1 dB steps during a transition.
+  uint32_t samples_per_step{0};
+  // Direction of each step: +1 while getting quieter, -1 while getting louder.
+  int8_t db_change_per_step{0};
+};
+
+/// @brief Schedules a new ducking level, optionally ramped over a number of samples.
+///
+/// If the requested level differs from the current target, the current target becomes the new
+/// starting point and the state ramps 1 dB at a time toward `decibel_reduction`. With
+/// `transition_samples == 0` (or no intermediate steps needed) the change is immediate. Calling
+/// this with the level already in effect is a no-op, so it is safe to call every block.
+///
+/// @param state Ducking state to update.
+/// @param decibel_reduction Target attenuation in dB; clamped to [0, MAX_DB_REDUCTION].
+/// @param transition_samples Length of the ramp in samples (per channel-interleaved sample count
+///                           is fine as long as it matches what is passed to apply()). 0 = instant.
+void set_target(DuckingState &state, uint8_t decibel_reduction, uint32_t transition_samples);
+
+/// @brief Applies the current ducking attenuation to a block of interleaved PCM samples in place.
+///
+/// Advances any in-progress transition as it goes, scaling each sub-range by the appropriate
+/// fixed-point factor (via gain::apply). When the state is settled at 0 dB this is a no-op.
+///
+/// Sample format matches gain::apply: signed PCM, little-endian, interleaved; 8-bit is int8.
+///
+/// @param buffer Interleaved samples to attenuate in place.
+/// @param bytes_per_sample Sample width in bytes: 1, 2, 3, or 4.
+/// @param samples Number of samples (not frames) in the buffer.
+/// @param state Ducking state; updated to reflect any transition progress.
+void apply(uint8_t *buffer, uint8_t bytes_per_sample, uint32_t samples, DuckingState &state);
+
+}  // namespace ducking
+}  // namespace esp_audio_libs

--- a/include/mixer.h
+++ b/include/mixer.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace esp_audio_libs {
+namespace mixer {
+
+/// @brief Sums two interleaved PCM streams into an output buffer.
+///
+/// The two inputs and the output may each have a different bit depth and channel count. Channel
+/// mapping follows the same rule as pcm_convert::copy_frames: extra output channels reuse the
+/// last source channel, surplus source channels are dropped.
+///
+/// Mixing is done in Q30 (each Q31 input is shifted right by one before summing) so the running
+/// total stays in a 32-bit register with no 64-bit arithmetic. The sum is clamped to the Q30
+/// range, then shifted back to Q31 for output. The cost is one LSB of resolution per input;
+/// negligible at every supported bit depth. Chain more than two streams by passing a previous
+/// mix result back in as `primary`.
+///
+/// Sample format: signed PCM, little-endian for multi-byte widths, interleaved across channels.
+/// The output buffer must not overlap either input. Misaligned pointers are handled correctly via
+/// a runtime dispatch, but aligning each pointer to its sample width (2 bytes for 16-bit, 4 bytes
+/// for 32-bit) lets the function take the wide-load fast path on architectures like Xtensa.
+///
+/// @param primary First source buffer.
+/// @param primary_bps First source sample width in bytes: 1, 2, 3, or 4. Other values are a no-op.
+/// @param primary_channels Number of channels in the first source (must be >= 1).
+/// @param secondary Second source buffer.
+/// @param secondary_bps Second source sample width in bytes: 1, 2, 3, or 4.
+/// @param secondary_channels Number of channels in the second source (must be >= 1).
+/// @param output Destination buffer (must not alias either input).
+/// @param output_bps Destination sample width in bytes: 1, 2, 3, or 4.
+/// @param output_channels Number of destination channels (must be >= 1).
+/// @param frames Number of frames to mix.
+void mix_frames(const uint8_t *primary, uint8_t primary_bps, uint8_t primary_channels, const uint8_t *secondary,
+                uint8_t secondary_bps, uint8_t secondary_channels, uint8_t *output, uint8_t output_bps,
+                uint8_t output_channels, uint32_t frames);
+
+}  // namespace mixer
+}  // namespace esp_audio_libs

--- a/include/pcm_convert.h
+++ b/include/pcm_convert.h
@@ -1,0 +1,42 @@
+#pragma once
+
+/// @file pcm_convert.h
+/// @brief Interleaved PCM conversion between bit depths and channel counts
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace esp_audio_libs {
+namespace pcm_convert {
+
+/// @brief Converts interleaved PCM frames between bit depths and channel counts
+///
+/// Each output frame is built channel-by-channel. When the output has more channels than the
+/// input, the extra channels reuse the last input channel; when it has fewer, the trailing input
+/// channels are dropped. Bit-depth conversion goes through a Q31 intermediate: widening is exact,
+/// narrowing truncates the low bits (no dithering). When the input and output formats match
+/// exactly this degenerates to a plain memcpy.
+///
+/// Sample format: signed PCM, little-endian for multi-byte widths, interleaved across channels.
+/// 8-bit samples are interpreted as int8 (0x00 is silence), not WAV-style uint8.
+///
+/// The buffers must not overlap. Misaligned pointers are handled correctly via a runtime
+/// dispatch, but aligning each pointer to its sample width (2 bytes for 16-bit, 4 bytes for
+/// 32-bit) lets the function take the wide-load fast path on architectures like Xtensa.
+///
+/// @note The total byte count `frames * input_channels * input_bps` must fit in `size_t`. On
+/// 32-bit targets that caps a single call at ~4 GiB of input, well beyond any realistic audio
+/// buffer; the caller is responsible for not exceeding it.
+///
+/// @param input Source buffer of interleaved samples.
+/// @param output Destination buffer (must not alias the input).
+/// @param input_bps Source sample width in bytes: 1, 2, 3, or 4. Other values are a no-op.
+/// @param input_channels Number of source channels (must be >= 1).
+/// @param output_bps Destination sample width in bytes: 1, 2, 3, or 4. Other values are a no-op.
+/// @param output_channels Number of destination channels (must be >= 1).
+/// @param frames Number of frames to convert. Zero is a no-op.
+void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8_t input_channels, uint8_t output_bps,
+                 uint8_t output_channels, uint32_t frames);
+
+}  // namespace pcm_convert
+}  // namespace esp_audio_libs

--- a/include/pcm_convert.h
+++ b/include/pcm_convert.h
@@ -24,9 +24,11 @@ namespace pcm_convert {
 /// dispatch, but aligning each pointer to its sample width (2 bytes for 16-bit, 4 bytes for
 /// 32-bit) lets the function take the wide-load fast path on architectures like Xtensa.
 ///
-/// @note The total byte count `frames * input_channels * input_bps` must fit in `size_t`. On
-/// 32-bit targets that caps a single call at ~4 GiB of input, well beyond any realistic audio
-/// buffer; the caller is responsible for not exceeding it.
+/// @note The total byte count `frames * input_channels * input_bps` must fit in `size_t`, and
+/// `frames * input_channels` must fit in `uint32_t`. On 32-bit targets the first condition implies
+/// the second and caps a single call at ~4 GiB of input, well beyond any realistic audio buffer.
+/// On 64-bit hosts `size_t` is wider, so the caller must keep `frames * input_channels` within
+/// `uint32_t` directly. The caller is responsible for not exceeding these limits.
 ///
 /// @param input Source buffer of interleaved samples.
 /// @param output Destination buffer (must not alias the input).

--- a/src/compiler.h
+++ b/src/compiler.h
@@ -18,6 +18,14 @@
 #define EAL_MEMCPY(dst, src, n) std::memcpy((dst), (src), (n))
 #endif
 
+// Mark a function as hot: optimize it aggressively and group it with other hot code for better
+// instruction-cache locality. No-op on compilers without the attribute.
+#if defined(__GNUC__) || defined(__clang__)
+#define EAL_HOT __attribute__((hot))
+#else
+#define EAL_HOT
+#endif
+
 // Tell the optimizer that `ptr` is aligned to `n` bytes. Caller is responsible
 // for guaranteeing the precondition (typically via a runtime check). Lets
 // follow-up loads/stores fold into single aligned-access instructions on

--- a/src/ducking.cpp
+++ b/src/ducking.cpp
@@ -1,0 +1,103 @@
+#include "ducking.h"
+
+#include <algorithm>
+
+#include "gain.h"
+
+namespace esp_audio_libs {
+namespace ducking {
+
+namespace {
+
+/// Q31 scale factor for an integer dB reduction in [0, MAX_DB_REDUCTION], computed by iterative
+/// multiplication by 10^(-1/20) in Q32 fixed-point (3827893632 = 2 * round(10^(-1/20) * 2^31)).
+/// The unsigned 32x32 -> high-32 multiply lowers to a single MULUH (Xtensa) / MULHU (RISC-V).
+/// Pure integer math, so it is cheap to recompute per block.
+int32_t db_reduction_to_q31(uint8_t db) {
+  int32_t factor = INT32_MAX;  // 0 dB = unity gain
+  for (uint8_t i = 0; i < db; ++i) {
+    factor = static_cast<int32_t>((static_cast<uint64_t>(factor) * 3827893632ULL) >> 32);
+  }
+  return factor;
+}
+
+uint8_t clamp_db(int8_t db) {
+  if (db < 0)
+    return 0;
+  if (db > static_cast<int8_t>(MAX_DB_REDUCTION))
+    return MAX_DB_REDUCTION;
+  return static_cast<uint8_t>(db);
+}
+
+}  // namespace
+
+void set_target(DuckingState &state, uint8_t decibel_reduction, uint32_t transition_samples) {
+  if (decibel_reduction > MAX_DB_REDUCTION)
+    decibel_reduction = MAX_DB_REDUCTION;
+
+  if (state.target_db_reduction == decibel_reduction)
+    return;
+
+  // Start the ramp from the previous target (which becomes the new current level).
+  state.current_db_reduction = static_cast<int8_t>(state.target_db_reduction);
+  state.target_db_reduction = decibel_reduction;
+
+  // Number of intermediate 1 dB steps. Subtract 1 because the first step is taken immediately.
+  uint8_t total_steps = 0;
+  if (state.target_db_reduction > state.current_db_reduction) {
+    total_steps = static_cast<uint8_t>(state.target_db_reduction - state.current_db_reduction - 1);
+    state.db_change_per_step = 1;
+  } else {
+    total_steps = static_cast<uint8_t>(state.current_db_reduction - state.target_db_reduction - 1);
+    state.db_change_per_step = -1;
+  }
+
+  if (transition_samples > 0 && total_steps > 0) {
+    state.samples_per_step = transition_samples / total_steps;
+    // Re-derive remaining samples so it is an exact multiple of samples_per_step.
+    state.transition_samples_remaining = state.samples_per_step * total_steps;
+    state.current_db_reduction += state.db_change_per_step;
+  } else {
+    state.transition_samples_remaining = 0;
+    state.current_db_reduction = static_cast<int8_t>(state.target_db_reduction);
+  }
+}
+
+void apply(uint8_t *buffer, uint8_t bytes_per_sample, uint32_t samples, DuckingState &state) {
+  // Safety guard: a transition must have a nonzero step size.
+  if (state.transition_samples_remaining > 0 && state.samples_per_step == 0)
+    state.transition_samples_remaining = 0;
+
+  if (state.transition_samples_remaining > 0) {
+    // Ceiling of samples / samples_per_step.
+    uint32_t steps_in_batch = samples / state.samples_per_step + (samples % state.samples_per_step != 0 ? 1 : 0);
+
+    for (uint32_t i = 0; i < steps_in_batch; ++i) {
+      uint32_t samples_left_in_step = state.transition_samples_remaining % state.samples_per_step;
+      if (samples_left_in_step == 0)
+        samples_left_in_step = state.samples_per_step;
+
+      uint32_t chunk = std::min(samples, samples_left_in_step);
+      chunk = std::min(chunk, state.transition_samples_remaining);
+
+      const int32_t q31 = db_reduction_to_q31(clamp_db(state.current_db_reduction));
+      gain::apply(buffer, buffer, q31, chunk, bytes_per_sample);
+
+      if (samples_left_in_step == chunk)
+        state.current_db_reduction += state.db_change_per_step;
+
+      buffer += chunk * bytes_per_sample;
+      state.transition_samples_remaining -= chunk;
+      samples -= chunk;
+    }
+  }
+
+  if (state.current_db_reduction > 0 && samples > 0) {
+    // Settled (or settled enough): one scale for the rest of the block.
+    const int32_t q31 = db_reduction_to_q31(clamp_db(state.current_db_reduction));
+    gain::apply(buffer, buffer, q31, samples, bytes_per_sample);
+  }
+}
+
+}  // namespace ducking
+}  // namespace esp_audio_libs

--- a/src/ducking.cpp
+++ b/src/ducking.cpp
@@ -52,12 +52,15 @@ void set_target(DuckingState &state, uint8_t decibel_reduction, uint32_t transit
     state.db_change_per_step = -1;
   }
 
-  if (transition_samples > 0 && total_steps > 0) {
+  if (transition_samples > 0 && total_steps > 0 && transition_samples / total_steps > 0) {
     state.samples_per_step = transition_samples / total_steps;
     // Re-derive remaining samples so it is an exact multiple of samples_per_step.
     state.transition_samples_remaining = state.samples_per_step * total_steps;
     state.current_db_reduction += state.db_change_per_step;
   } else {
+    // No transition time, no intermediate steps, or too few samples to give each step at least one
+    // sample (samples_per_step would round to 0): jump straight to the target rather than stalling
+    // the ramp partway.
     state.transition_samples_remaining = 0;
     state.current_db_reduction = static_cast<int8_t>(state.target_db_reduction);
   }

--- a/src/gain.cpp
+++ b/src/gain.cpp
@@ -4,56 +4,10 @@
 #include <cstdint>
 
 #include "compiler.h"
+#include "q31_utils.h"
 
 namespace esp_audio_libs {
 namespace gain {
-
-namespace {
-
-/// Load a sample of `bytes_per_sample` bytes and place it in Q31 form (sign extended into the
-/// upper bits of an int32). Byte-wise access, so it is safe for any pointer alignment.
-inline int32_t unpack_audio_sample_to_q31(const uint8_t *data, size_t bytes_per_sample) {
-  uint32_t sample = 0;
-  if (bytes_per_sample == 1) {
-    sample |= static_cast<uint32_t>(data[0]) << 24;
-  } else if (bytes_per_sample == 2) {
-    sample |= static_cast<uint32_t>(data[0]) << 16;
-    sample |= static_cast<uint32_t>(data[1]) << 24;
-  } else if (bytes_per_sample == 3) {
-    sample |= static_cast<uint32_t>(data[0]) << 8;
-    sample |= static_cast<uint32_t>(data[1]) << 16;
-    sample |= static_cast<uint32_t>(data[2]) << 24;
-  } else if (bytes_per_sample == 4) {
-    sample |= static_cast<uint32_t>(data[0]);
-    sample |= static_cast<uint32_t>(data[1]) << 8;
-    sample |= static_cast<uint32_t>(data[2]) << 16;
-    sample |= static_cast<uint32_t>(data[3]) << 24;
-  }
-  return static_cast<int32_t>(sample);
-}
-
-/// Pack a Q31 sample as `bytes_per_sample` bytes, keeping the most significant bytes. Byte-wise
-/// access, so it is safe for any pointer alignment. The caller is responsible for adding any
-/// rounding term to `sample` before calling.
-inline void pack_q31_as_audio_sample(int32_t sample, uint8_t *data, size_t bytes_per_sample) {
-  if (bytes_per_sample == 1) {
-    data[0] = static_cast<uint8_t>(sample >> 24);
-  } else if (bytes_per_sample == 2) {
-    data[0] = static_cast<uint8_t>(sample >> 16);
-    data[1] = static_cast<uint8_t>(sample >> 24);
-  } else if (bytes_per_sample == 3) {
-    data[0] = static_cast<uint8_t>(sample >> 8);
-    data[1] = static_cast<uint8_t>(sample >> 16);
-    data[2] = static_cast<uint8_t>(sample >> 24);
-  } else if (bytes_per_sample == 4) {
-    data[0] = static_cast<uint8_t>(sample);
-    data[1] = static_cast<uint8_t>(sample >> 8);
-    data[2] = static_cast<uint8_t>(sample >> 16);
-    data[3] = static_cast<uint8_t>(sample >> 24);
-  }
-}
-
-}  // namespace
 
 int32_t db_to_q31(float db) {
   if (std::isnan(db)) {
@@ -80,24 +34,23 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
   // This yields a Q30 result in int32. That int32 sample is shifted to restore the original bit
   // width. A rounding term is added for the 8 bit, 16 bit, and 24 bit cases.
   //
-  // The 16 and 32 bit cases load samples via EAL_MEMCPY into local int16_t/int32_t variables.
-  // After EAL_ASSUME_ALIGNED, the compiler folds these into single-instruction aligned loads
-  // (l16si/l32i on Xtensa). Xtensa raises an alignment exception on misaligned word/halfword
-  // loads, so a runtime check gates this path; misaligned buffers fall back to a byte-wise
-  // slow path that produces identical output.
+  // The 16 and 32 bit cases dispatch on a runtime alignment check: aligned buffers use the
+  // fast_unpack_to_q31<> helper (which folds the load into a single l16si/l32i on Xtensa), and
+  // misaligned buffers fall back to the byte-wise unpack_to_q31<> path that produces identical
+  // output. Xtensa raises an alignment exception on misaligned word/halfword loads, so the
+  // runtime gate is required.
   switch (bytes_per_sample) {
     case 1: {
       // 8 bit input shifted left by 24 to reach Q31. The high-half multiply produces s * sf >> 8.
       // Shift right by 23 to recover the 8 bit sample. Rounding term is 1 << 22.
       constexpr int32_t rounding = 1 << 22;
-      const int8_t *in = reinterpret_cast<const int8_t *>(audio_samples);
       int8_t *out = reinterpret_cast<int8_t *>(output_buffer);
       size_t i = 0;
       for (; i + 4 <= samples_to_scale; i += 4) {
-        const int32_t s0 = static_cast<int32_t>(static_cast<uint32_t>(in[i]) << 24);
-        const int32_t s1 = static_cast<int32_t>(static_cast<uint32_t>(in[i + 1]) << 24);
-        const int32_t s2 = static_cast<int32_t>(static_cast<uint32_t>(in[i + 2]) << 24);
-        const int32_t s3 = static_cast<int32_t>(static_cast<uint32_t>(in[i + 3]) << 24);
+        const int32_t s0 = internal::unpack_to_q31<1>(audio_samples + i);
+        const int32_t s1 = internal::unpack_to_q31<1>(audio_samples + i + 1);
+        const int32_t s2 = internal::unpack_to_q31<1>(audio_samples + i + 2);
+        const int32_t s3 = internal::unpack_to_q31<1>(audio_samples + i + 3);
         const int32_t high0 =
             static_cast<int32_t>((static_cast<int64_t>(s0) * static_cast<int64_t>(q31_scale)) >> 32);
         const int32_t high1 =
@@ -112,7 +65,7 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
         out[i + 3] = static_cast<int8_t>((high3 + rounding) >> 23);
       }
       for (; i < samples_to_scale; ++i) {
-        const int32_t s = static_cast<int32_t>(static_cast<uint32_t>(in[i]) << 24);
+        const int32_t s = internal::unpack_to_q31<1>(audio_samples + i);
         const int32_t high =
             static_cast<int32_t>((static_cast<int64_t>(s) * static_cast<int64_t>(q31_scale)) >> 32);
         out[i] = static_cast<int8_t>((high + rounding) >> 23);
@@ -127,22 +80,17 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
                              reinterpret_cast<uintptr_t>(output_buffer)) &
                             0x1) == 0;
       if (aligned) {
-        // EAL_MEMCPY avoids strict-aliasing UB. EAL_ASSUME_ALIGNED tells the compiler the buffers
-        // are 2-byte aligned (which the runtime check above just established) so the memcpy folds
-        // to a single l16si/s16i instead of byte-wise loads.
-        const uint8_t *in = static_cast<const uint8_t *>(EAL_ASSUME_ALIGNED(audio_samples, 2));
+        // Output stores use EAL_MEMCPY (to avoid strict-aliasing UB) with EAL_ASSUME_ALIGNED on
+        // `out` (just established by the runtime check above) so each memcpy folds to a single
+        // s16i on Xtensa. Aligned input loads are handled inside fast_unpack_to_q31<2>.
+        const uint8_t *in = audio_samples;
         uint8_t *out = static_cast<uint8_t *>(EAL_ASSUME_ALIGNED(output_buffer, 2));
         size_t i = 0;
         for (; i + 4 <= samples_to_scale; i += 4) {
-          int16_t v0, v1, v2, v3;
-          EAL_MEMCPY(&v0, in + (i + 0) * 2, sizeof(int16_t));
-          EAL_MEMCPY(&v1, in + (i + 1) * 2, sizeof(int16_t));
-          EAL_MEMCPY(&v2, in + (i + 2) * 2, sizeof(int16_t));
-          EAL_MEMCPY(&v3, in + (i + 3) * 2, sizeof(int16_t));
-          const int32_t s0 = static_cast<int32_t>(static_cast<uint32_t>(v0) << 16);
-          const int32_t s1 = static_cast<int32_t>(static_cast<uint32_t>(v1) << 16);
-          const int32_t s2 = static_cast<int32_t>(static_cast<uint32_t>(v2) << 16);
-          const int32_t s3 = static_cast<int32_t>(static_cast<uint32_t>(v3) << 16);
+          const int32_t s0 = internal::fast_unpack_to_q31<2>(in + (i + 0) * 2);
+          const int32_t s1 = internal::fast_unpack_to_q31<2>(in + (i + 1) * 2);
+          const int32_t s2 = internal::fast_unpack_to_q31<2>(in + (i + 2) * 2);
+          const int32_t s3 = internal::fast_unpack_to_q31<2>(in + (i + 3) * 2);
           const int32_t high0 =
               static_cast<int32_t>((static_cast<int64_t>(s0) * static_cast<int64_t>(q31_scale)) >> 32);
           const int32_t high1 =
@@ -161,9 +109,7 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
           EAL_MEMCPY(out + (i + 3) * 2, &r3, sizeof(int16_t));
         }
         for (; i < samples_to_scale; ++i) {
-          int16_t v;
-          EAL_MEMCPY(&v, in + i * 2, sizeof(int16_t));
-          const int32_t s = static_cast<int32_t>(static_cast<uint32_t>(v) << 16);
+          const int32_t s = internal::fast_unpack_to_q31<2>(in + i * 2);
           const int32_t high =
               static_cast<int32_t>((static_cast<int64_t>(s) * static_cast<int64_t>(q31_scale)) >> 32);
           const int16_t r = static_cast<int16_t>((high + rounding) >> 15);
@@ -173,13 +119,13 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
         for (size_t i = 0; i < samples_to_scale; ++i) {
           const uint8_t *p_in = audio_samples + (i * 2);
           uint8_t *p_out = output_buffer + (i * 2);
-          const int32_t s = unpack_audio_sample_to_q31(p_in, 2);
+          const int32_t s = internal::unpack_to_q31<2>(p_in);
           const int32_t high =
               static_cast<int32_t>((static_cast<int64_t>(s) * static_cast<int64_t>(q31_scale)) >> 32);
           // Round and convert Q30 to Q31 form so pack keeps the right bytes.
           const int32_t scaled_q31 =
               static_cast<int32_t>(static_cast<uint32_t>(high + rounding) << 1);
-          pack_q31_as_audio_sample(scaled_q31, p_out, 2);
+          internal::pack_q31<2>(scaled_q31, p_out);
         }
       }
       break;
@@ -191,11 +137,7 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
       for (size_t i = 0; i < samples_to_scale; ++i) {
         const uint8_t *p_in = audio_samples + (i * 3);
         uint8_t *p_out = output_buffer + (i * 3);
-        // Little-endian 24 bit load with sign extension from bit 23.
-        const int32_t sample =
-            static_cast<int32_t>(static_cast<uint32_t>(p_in[0]) | (static_cast<uint32_t>(p_in[1]) << 8) |
-                                 (static_cast<uint32_t>(p_in[2]) << 16) | ((p_in[2] & 0x80) ? 0xFF000000u : 0u));
-        const int32_t s = static_cast<int32_t>(static_cast<uint32_t>(sample) << 8);
+        const int32_t s = internal::unpack_to_q31<3>(p_in);
         const int32_t high =
             static_cast<int32_t>((static_cast<int64_t>(s) * static_cast<int64_t>(q31_scale)) >> 32);
         const int32_t scaled = (high + rounding) >> 7;
@@ -214,18 +156,17 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
                              reinterpret_cast<uintptr_t>(output_buffer)) &
                             0x3) == 0;
       if (aligned) {
-        // EAL_MEMCPY avoids strict-aliasing UB. EAL_ASSUME_ALIGNED tells the compiler the buffers
-        // are 4-byte aligned (which the runtime check above just established) so the memcpy folds
-        // to a single l32i/s32i instead of byte-wise loads.
-        const uint8_t *in = static_cast<const uint8_t *>(EAL_ASSUME_ALIGNED(audio_samples, 4));
+        // Output stores use EAL_MEMCPY (to avoid strict-aliasing UB) with EAL_ASSUME_ALIGNED on
+        // `out` (just established by the runtime check above) so each memcpy folds to a single
+        // s32i on Xtensa. Aligned input loads are handled inside fast_unpack_to_q31<4>.
+        const uint8_t *in = audio_samples;
         uint8_t *out = static_cast<uint8_t *>(EAL_ASSUME_ALIGNED(output_buffer, 4));
         size_t i = 0;
         for (; i + 4 <= samples_to_scale; i += 4) {
-          int32_t v0, v1, v2, v3;
-          EAL_MEMCPY(&v0, in + (i + 0) * 4, sizeof(int32_t));
-          EAL_MEMCPY(&v1, in + (i + 1) * 4, sizeof(int32_t));
-          EAL_MEMCPY(&v2, in + (i + 2) * 4, sizeof(int32_t));
-          EAL_MEMCPY(&v3, in + (i + 3) * 4, sizeof(int32_t));
+          const int32_t v0 = internal::fast_unpack_to_q31<4>(in + (i + 0) * 4);
+          const int32_t v1 = internal::fast_unpack_to_q31<4>(in + (i + 1) * 4);
+          const int32_t v2 = internal::fast_unpack_to_q31<4>(in + (i + 2) * 4);
+          const int32_t v3 = internal::fast_unpack_to_q31<4>(in + (i + 3) * 4);
           const int32_t high0 =
               static_cast<int32_t>((static_cast<int64_t>(v0) * static_cast<int64_t>(q31_scale)) >> 32);
           const int32_t high1 =
@@ -244,8 +185,7 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
           EAL_MEMCPY(out + (i + 3) * 4, &r3, sizeof(int32_t));
         }
         for (; i < samples_to_scale; ++i) {
-          int32_t v;
-          EAL_MEMCPY(&v, in + i * 4, sizeof(int32_t));
+          const int32_t v = internal::fast_unpack_to_q31<4>(in + i * 4);
           const int32_t high =
               static_cast<int32_t>((static_cast<int64_t>(v) * static_cast<int64_t>(q31_scale)) >> 32);
           const int32_t r = static_cast<int32_t>(static_cast<uint32_t>(high) << 1);
@@ -255,11 +195,11 @@ void apply(const uint8_t *audio_samples, uint8_t *output_buffer, int32_t q31_sca
         for (size_t i = 0; i < samples_to_scale; ++i) {
           const uint8_t *p_in = audio_samples + (i * 4);
           uint8_t *p_out = output_buffer + (i * 4);
-          const int32_t s = unpack_audio_sample_to_q31(p_in, 4);
+          const int32_t s = internal::unpack_to_q31<4>(p_in);
           const int32_t high =
               static_cast<int32_t>((static_cast<int64_t>(s) * static_cast<int64_t>(q31_scale)) >> 32);
           const int32_t scaled_q31 = static_cast<int32_t>(static_cast<uint32_t>(high) << 1);
-          pack_q31_as_audio_sample(scaled_q31, p_out, 4);
+          internal::pack_q31<4>(scaled_q31, p_out);
         }
       }
       break;

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -15,6 +15,18 @@ using internal::fast_unpack_to_q31;
 using internal::pack_q31;
 using internal::unpack_to_q31;
 
+// Mix in Q30 so the sum stays in a 32-bit register; the right shift loses 1 LSB per input.
+constexpr int32_t Q30_MIN = -(INT32_C(1) << 30);
+constexpr int32_t Q30_MAX = (INT32_C(1) << 30) - 1;
+
+// Sum two Q31 inputs into a saturated Q31 output. Each input is halved before adding so the sum
+// stays in int32; the result is clamped to the Q30 range and shifted back to Q31, which
+// preventsthe left shift from overflowing.
+EAL_HOT inline int32_t mix_q31(int32_t primary_q31, int32_t secondary_q31) {
+  const int32_t sum_q30 = (primary_q31 >> 1) + (secondary_q31 >> 1);
+  return std::min(std::max(sum_q30, Q30_MIN), Q30_MAX) << 1;
+}
+
 // Pick the fast (aligned wide-load) or byte-wise variant at compile time. The `Aligned` template
 // flag is set by the runtime alignment check in mix_frames(); both branches fold away at -O2.
 template<size_t Bps, bool Aligned> EAL_HOT inline int32_t unpack(const uint8_t *data) {
@@ -32,104 +44,121 @@ template<size_t Bps, bool Aligned> EAL_HOT inline void pack(int32_t sample, uint
   }
 }
 
-template<size_t PrimaryBps, size_t SecondaryBps, size_t OutputBps, bool Aligned>
-EAL_HOT void mix_frames_impl(const uint8_t *pri_ptr, uint8_t primary_channels, const uint8_t *sec_ptr,
-                             uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels, uint32_t frames) {
+// Hot path: the two inputs and the output all share one sample width. Templating on a single `Bps`
+// (instead of the full primary x secondary x output matrix) keeps this fully inlined and a
+// zero-overhead-loop candidate while collapsing the instantiation count from 4*4*4 to 4 per
+// alignment variant.
+template<size_t Bps, bool Aligned>
+EAL_HOT void mix_frames_same_bps(const uint8_t *pri_ptr, uint8_t primary_channels, const uint8_t *sec_ptr,
+                                 uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels,
+                                 uint32_t frames) {
   const uint8_t max_primary_channel_index = primary_channels - 1;
   const uint8_t max_secondary_channel_index = secondary_channels - 1;
-
-  // Mix in Q30 so the sum stays in a 32-bit register; the right shift loses 1 LSB per input.
-  constexpr int32_t Q30_MIN = -(INT32_C(1) << 30);
-  constexpr int32_t Q30_MAX = (INT32_C(1) << 30) - 1;
 
   for (uint32_t frame = 0; frame < frames; ++frame) {
     for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
       const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
-      const int32_t primary_q31 = unpack<PrimaryBps, Aligned>(pri_ptr + pri_ch * PrimaryBps);
+      const int32_t primary_q31 = unpack<Bps, Aligned>(pri_ptr + pri_ch * Bps);
 
       const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
-      const int32_t secondary_q31 = unpack<SecondaryBps, Aligned>(sec_ptr + sec_ch * SecondaryBps);
+      const int32_t secondary_q31 = unpack<Bps, Aligned>(sec_ptr + sec_ch * Bps);
 
-      const int32_t sum_q30 = (primary_q31 >> 1) + (secondary_q31 >> 1);
-      const int32_t clamped_q31 = std::min(std::max(sum_q30, Q30_MIN), Q30_MAX) << 1;
-
-      pack<OutputBps, Aligned>(clamped_q31, out_ptr + out_ch * OutputBps);
+      pack<Bps, Aligned>(mix_q31(primary_q31, secondary_q31), out_ptr + out_ch * Bps);
     }
-    pri_ptr += primary_channels * PrimaryBps;
-    sec_ptr += secondary_channels * SecondaryBps;
+    pri_ptr += primary_channels * Bps;
+    sec_ptr += secondary_channels * Bps;
+    out_ptr += output_channels * Bps;
+  }
+}
+
+// Runtime-width unpack for the mismatched-width path. A width switch on a loop-invariant `bps`
+// (well predicted) replaces the per-input-width template axis, so only the output width and the
+// alignment flag stay as template parameters. The `Aligned` flag selects the wide-load variant;
+// callers guarantee each buffer is aligned to its own width before picking it.
+template<bool Aligned> EAL_HOT inline int32_t unpack_runtime(const uint8_t *data, uint8_t bps) {
+  switch (bps) {
+    case 1:
+      return unpack<1, Aligned>(data);
+    case 2:
+      return unpack<2, Aligned>(data);
+    case 3:
+      return unpack<3, Aligned>(data);
+    default:
+      return unpack<4, Aligned>(data);
+  }
+}
+
+// Mismatched-width path: the three buffers do not share one sample width. The output width and
+// alignment are template parameters (so the per-output-sample pack is the inlined wide store and
+// carries no switch), while the two input widths are resolved by the runtime switch above.
+template<size_t OutputBps, bool Aligned>
+EAL_HOT void mix_frames_generic(const uint8_t *pri_ptr, uint8_t primary_bps, uint8_t primary_channels,
+                                const uint8_t *sec_ptr, uint8_t secondary_bps, uint8_t secondary_channels,
+                                uint8_t *out_ptr, uint8_t output_channels, uint32_t frames) {
+  const uint8_t max_primary_channel_index = primary_channels - 1;
+  const uint8_t max_secondary_channel_index = secondary_channels - 1;
+
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+      const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
+      const int32_t primary_q31 = unpack_runtime<Aligned>(pri_ptr + pri_ch * primary_bps, primary_bps);
+
+      const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
+      const int32_t secondary_q31 = unpack_runtime<Aligned>(sec_ptr + sec_ch * secondary_bps, secondary_bps);
+
+      pack<OutputBps, Aligned>(mix_q31(primary_q31, secondary_q31), out_ptr + out_ch * OutputBps);
+    }
+    pri_ptr += primary_channels * primary_bps;
+    sec_ptr += secondary_channels * secondary_bps;
     out_ptr += output_channels * OutputBps;
   }
 }
 
-template<size_t PrimaryBps, size_t SecondaryBps, bool Aligned>
-void mix_frames_dispatch_output(uint8_t output_bps, const uint8_t *pri_ptr, uint8_t primary_channels,
-                                const uint8_t *sec_ptr, uint8_t secondary_channels, uint8_t *out_ptr,
-                                uint8_t output_channels, uint32_t frames) {
+template<bool Aligned>
+void mix_frames_dispatch_generic(uint8_t output_bps, const uint8_t *pri_ptr, uint8_t primary_bps,
+                                 uint8_t primary_channels, const uint8_t *sec_ptr, uint8_t secondary_bps,
+                                 uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels,
+                                 uint32_t frames) {
   switch (output_bps) {
     case 1:
-      mix_frames_impl<PrimaryBps, SecondaryBps, 1, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
-                                                            out_ptr, output_channels, frames);
+      mix_frames_generic<1, Aligned>(pri_ptr, primary_bps, primary_channels, sec_ptr, secondary_bps,
+                                     secondary_channels, out_ptr, output_channels, frames);
       break;
     case 2:
-      mix_frames_impl<PrimaryBps, SecondaryBps, 2, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
-                                                            out_ptr, output_channels, frames);
+      mix_frames_generic<2, Aligned>(pri_ptr, primary_bps, primary_channels, sec_ptr, secondary_bps,
+                                     secondary_channels, out_ptr, output_channels, frames);
       break;
     case 3:
-      mix_frames_impl<PrimaryBps, SecondaryBps, 3, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
-                                                            out_ptr, output_channels, frames);
+      mix_frames_generic<3, Aligned>(pri_ptr, primary_bps, primary_channels, sec_ptr, secondary_bps,
+                                     secondary_channels, out_ptr, output_channels, frames);
       break;
     case 4:
-      mix_frames_impl<PrimaryBps, SecondaryBps, 4, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
-                                                            out_ptr, output_channels, frames);
-      break;
-  }
-}
-
-template<size_t PrimaryBps, bool Aligned>
-void mix_frames_dispatch_secondary(uint8_t secondary_bps, uint8_t output_bps, const uint8_t *pri_ptr,
-                                   uint8_t primary_channels, const uint8_t *sec_ptr, uint8_t secondary_channels,
-                                   uint8_t *out_ptr, uint8_t output_channels, uint32_t frames) {
-  switch (secondary_bps) {
-    case 1:
-      mix_frames_dispatch_output<PrimaryBps, 1, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                         secondary_channels, out_ptr, output_channels, frames);
-      break;
-    case 2:
-      mix_frames_dispatch_output<PrimaryBps, 2, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                         secondary_channels, out_ptr, output_channels, frames);
-      break;
-    case 3:
-      mix_frames_dispatch_output<PrimaryBps, 3, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                         secondary_channels, out_ptr, output_channels, frames);
-      break;
-    case 4:
-      mix_frames_dispatch_output<PrimaryBps, 4, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                         secondary_channels, out_ptr, output_channels, frames);
+      mix_frames_generic<4, Aligned>(pri_ptr, primary_bps, primary_channels, sec_ptr, secondary_bps,
+                                     secondary_channels, out_ptr, output_channels, frames);
       break;
   }
 }
 
 template<bool Aligned>
-void mix_frames_dispatch_primary(uint8_t primary_bps, uint8_t secondary_bps, uint8_t output_bps,
-                                 const uint8_t *pri_ptr, uint8_t primary_channels, const uint8_t *sec_ptr,
-                                 uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels,
-                                 uint32_t frames) {
-  switch (primary_bps) {
+void mix_frames_dispatch_same_bps(uint8_t bps, const uint8_t *pri_ptr, uint8_t primary_channels,
+                                  const uint8_t *sec_ptr, uint8_t secondary_channels, uint8_t *out_ptr,
+                                  uint8_t output_channels, uint32_t frames) {
+  switch (bps) {
     case 1:
-      mix_frames_dispatch_secondary<1, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                secondary_channels, out_ptr, output_channels, frames);
+      mix_frames_same_bps<1, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels, out_ptr,
+                                      output_channels, frames);
       break;
     case 2:
-      mix_frames_dispatch_secondary<2, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                secondary_channels, out_ptr, output_channels, frames);
+      mix_frames_same_bps<2, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels, out_ptr,
+                                      output_channels, frames);
       break;
     case 3:
-      mix_frames_dispatch_secondary<3, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                secondary_channels, out_ptr, output_channels, frames);
+      mix_frames_same_bps<3, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels, out_ptr,
+                                      output_channels, frames);
       break;
     case 4:
-      mix_frames_dispatch_secondary<4, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
-                                                secondary_channels, out_ptr, output_channels, frames);
+      mix_frames_same_bps<4, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels, out_ptr,
+                                      output_channels, frames);
       break;
   }
 }
@@ -152,18 +181,38 @@ void mix_frames(const uint8_t *primary, uint8_t primary_bps, uint8_t primary_cha
     return;
   }
 
-  // Pick the aligned fast path only if each buffer satisfies the alignment its own sample width
-  // requires; otherwise fall back to the byte-wise path.
-  const bool aligned = (reinterpret_cast<uintptr_t>(primary) & alignment_mask(primary_bps)) == 0 &&
-                       (reinterpret_cast<uintptr_t>(secondary) & alignment_mask(secondary_bps)) == 0 &&
-                       (reinterpret_cast<uintptr_t>(output) & alignment_mask(output_bps)) == 0;
+  // Mismatched widths route to the generic loop, specialized only on the output width and the
+  // alignment flag. Each buffer is checked against the alignment its own width requires; only when
+  // all three pass is the wide-load variant safe.
+  if (primary_bps != secondary_bps || primary_bps != output_bps) {
+    const bool generic_aligned = (reinterpret_cast<uintptr_t>(primary) & alignment_mask(primary_bps)) == 0 &&
+                                 (reinterpret_cast<uintptr_t>(secondary) & alignment_mask(secondary_bps)) == 0 &&
+                                 (reinterpret_cast<uintptr_t>(output) & alignment_mask(output_bps)) == 0;
+    if (generic_aligned) {
+      mix_frames_dispatch_generic<true>(output_bps, primary, primary_bps, primary_channels, secondary, secondary_bps,
+                                        secondary_channels, output, output_channels, frames);
+    } else {
+      mix_frames_dispatch_generic<false>(output_bps, primary, primary_bps, primary_channels, secondary, secondary_bps,
+                                         secondary_channels, output, output_channels, frames);
+    }
+    return;
+  }
+
+  const uint8_t bps = primary_bps;
+
+  // Pick the aligned fast path only if every buffer satisfies the alignment the shared sample width
+  // requires; otherwise fall back to the byte-wise variant.
+  const uintptr_t mask = alignment_mask(bps);
+  const bool aligned = (reinterpret_cast<uintptr_t>(primary) & mask) == 0 &&
+                       (reinterpret_cast<uintptr_t>(secondary) & mask) == 0 &&
+                       (reinterpret_cast<uintptr_t>(output) & mask) == 0;
 
   if (aligned) {
-    mix_frames_dispatch_primary<true>(primary_bps, secondary_bps, output_bps, primary, primary_channels, secondary,
-                                      secondary_channels, output, output_channels, frames);
+    mix_frames_dispatch_same_bps<true>(bps, primary, primary_channels, secondary, secondary_channels, output,
+                                       output_channels, frames);
   } else {
-    mix_frames_dispatch_primary<false>(primary_bps, secondary_bps, output_bps, primary, primary_channels, secondary,
-                                       secondary_channels, output, output_channels, frames);
+    mix_frames_dispatch_same_bps<false>(bps, primary, primary_channels, secondary, secondary_channels, output,
+                                        output_channels, frames);
   }
 }
 

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -152,13 +152,11 @@ void mix_frames(const uint8_t *primary, uint8_t primary_bps, uint8_t primary_cha
     return;
   }
 
-  // Pick the aligned fast path if every pointer satisfies the strictest sample-width alignment in
-  // use across the three buffers; otherwise fall back to the byte-wise path.
-  const uintptr_t align_mask =
-      alignment_mask(primary_bps) | alignment_mask(secondary_bps) | alignment_mask(output_bps);
-  const uintptr_t ptr_or = reinterpret_cast<uintptr_t>(primary) | reinterpret_cast<uintptr_t>(secondary) |
-                           reinterpret_cast<uintptr_t>(output);
-  const bool aligned = (ptr_or & align_mask) == 0;
+  // Pick the aligned fast path only if each buffer satisfies the alignment its own sample width
+  // requires; otherwise fall back to the byte-wise path.
+  const bool aligned = (reinterpret_cast<uintptr_t>(primary) & alignment_mask(primary_bps)) == 0 &&
+                       (reinterpret_cast<uintptr_t>(secondary) & alignment_mask(secondary_bps)) == 0 &&
+                       (reinterpret_cast<uintptr_t>(output) & alignment_mask(output_bps)) == 0;
 
   if (aligned) {
     mix_frames_dispatch_primary<true>(primary_bps, secondary_bps, output_bps, primary, primary_channels, secondary,

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -1,0 +1,173 @@
+#include "mixer.h"
+
+#include <algorithm>
+
+#include "compiler.h"
+#include "q31_utils.h"
+
+namespace esp_audio_libs {
+namespace mixer {
+
+namespace {
+
+using internal::fast_pack_q31;
+using internal::fast_unpack_to_q31;
+using internal::pack_q31;
+using internal::unpack_to_q31;
+
+// Pick the fast (aligned wide-load) or byte-wise variant at compile time. The `Aligned` template
+// flag is set by the runtime alignment check in mix_frames(); both branches fold away at -O2.
+template<size_t Bps, bool Aligned> EAL_HOT inline int32_t unpack(const uint8_t *data) {
+  if (Aligned) {
+    return fast_unpack_to_q31<Bps>(data);
+  }
+  return unpack_to_q31<Bps>(data);
+}
+
+template<size_t Bps, bool Aligned> EAL_HOT inline void pack(int32_t sample, uint8_t *data) {
+  if (Aligned) {
+    fast_pack_q31<Bps>(sample, data);
+  } else {
+    pack_q31<Bps>(sample, data);
+  }
+}
+
+template<size_t PrimaryBps, size_t SecondaryBps, size_t OutputBps, bool Aligned>
+EAL_HOT void mix_frames_impl(const uint8_t *pri_ptr, uint8_t primary_channels, const uint8_t *sec_ptr,
+                             uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels, uint32_t frames) {
+  const uint8_t max_primary_channel_index = primary_channels - 1;
+  const uint8_t max_secondary_channel_index = secondary_channels - 1;
+
+  // Mix in Q30 so the sum stays in a 32-bit register; the right shift loses 1 LSB per input.
+  constexpr int32_t Q30_MIN = -(INT32_C(1) << 30);
+  constexpr int32_t Q30_MAX = (INT32_C(1) << 30) - 1;
+
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+      const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
+      const int32_t primary_q31 = unpack<PrimaryBps, Aligned>(pri_ptr + pri_ch * PrimaryBps);
+
+      const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
+      const int32_t secondary_q31 = unpack<SecondaryBps, Aligned>(sec_ptr + sec_ch * SecondaryBps);
+
+      const int32_t sum_q30 = (primary_q31 >> 1) + (secondary_q31 >> 1);
+      const int32_t clamped_q31 = std::min(std::max(sum_q30, Q30_MIN), Q30_MAX) << 1;
+
+      pack<OutputBps, Aligned>(clamped_q31, out_ptr + out_ch * OutputBps);
+    }
+    pri_ptr += primary_channels * PrimaryBps;
+    sec_ptr += secondary_channels * SecondaryBps;
+    out_ptr += output_channels * OutputBps;
+  }
+}
+
+template<size_t PrimaryBps, size_t SecondaryBps, bool Aligned>
+void mix_frames_dispatch_output(uint8_t output_bps, const uint8_t *pri_ptr, uint8_t primary_channels,
+                                const uint8_t *sec_ptr, uint8_t secondary_channels, uint8_t *out_ptr,
+                                uint8_t output_channels, uint32_t frames) {
+  switch (output_bps) {
+    case 1:
+      mix_frames_impl<PrimaryBps, SecondaryBps, 1, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
+                                                            out_ptr, output_channels, frames);
+      break;
+    case 2:
+      mix_frames_impl<PrimaryBps, SecondaryBps, 2, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
+                                                            out_ptr, output_channels, frames);
+      break;
+    case 3:
+      mix_frames_impl<PrimaryBps, SecondaryBps, 3, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
+                                                            out_ptr, output_channels, frames);
+      break;
+    case 4:
+      mix_frames_impl<PrimaryBps, SecondaryBps, 4, Aligned>(pri_ptr, primary_channels, sec_ptr, secondary_channels,
+                                                            out_ptr, output_channels, frames);
+      break;
+  }
+}
+
+template<size_t PrimaryBps, bool Aligned>
+void mix_frames_dispatch_secondary(uint8_t secondary_bps, uint8_t output_bps, const uint8_t *pri_ptr,
+                                   uint8_t primary_channels, const uint8_t *sec_ptr, uint8_t secondary_channels,
+                                   uint8_t *out_ptr, uint8_t output_channels, uint32_t frames) {
+  switch (secondary_bps) {
+    case 1:
+      mix_frames_dispatch_output<PrimaryBps, 1, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                         secondary_channels, out_ptr, output_channels, frames);
+      break;
+    case 2:
+      mix_frames_dispatch_output<PrimaryBps, 2, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                         secondary_channels, out_ptr, output_channels, frames);
+      break;
+    case 3:
+      mix_frames_dispatch_output<PrimaryBps, 3, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                         secondary_channels, out_ptr, output_channels, frames);
+      break;
+    case 4:
+      mix_frames_dispatch_output<PrimaryBps, 4, Aligned>(output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                         secondary_channels, out_ptr, output_channels, frames);
+      break;
+  }
+}
+
+template<bool Aligned>
+void mix_frames_dispatch_primary(uint8_t primary_bps, uint8_t secondary_bps, uint8_t output_bps,
+                                 const uint8_t *pri_ptr, uint8_t primary_channels, const uint8_t *sec_ptr,
+                                 uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels,
+                                 uint32_t frames) {
+  switch (primary_bps) {
+    case 1:
+      mix_frames_dispatch_secondary<1, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                secondary_channels, out_ptr, output_channels, frames);
+      break;
+    case 2:
+      mix_frames_dispatch_secondary<2, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                secondary_channels, out_ptr, output_channels, frames);
+      break;
+    case 3:
+      mix_frames_dispatch_secondary<3, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                secondary_channels, out_ptr, output_channels, frames);
+      break;
+    case 4:
+      mix_frames_dispatch_secondary<4, Aligned>(secondary_bps, output_bps, pri_ptr, primary_channels, sec_ptr,
+                                                secondary_channels, out_ptr, output_channels, frames);
+      break;
+  }
+}
+
+// Required alignment for a sample width: 2 bytes for 16-bit (mask 0x1), 4 bytes for 32-bit (mask
+// 0x3). 1- and 3-byte widths are byte-wise and have no alignment requirement.
+inline uintptr_t alignment_mask(uint8_t bps) {
+  if (bps == 2) return 0x1;
+  if (bps == 4) return 0x3;
+  return 0;
+}
+
+}  // namespace
+
+void mix_frames(const uint8_t *primary, uint8_t primary_bps, uint8_t primary_channels, const uint8_t *secondary,
+                uint8_t secondary_bps, uint8_t secondary_channels, uint8_t *output, uint8_t output_bps,
+                uint8_t output_channels, uint32_t frames) {
+  if (frames == 0 || primary_channels == 0 || secondary_channels == 0 || output_channels == 0 || primary_bps < 1 ||
+      primary_bps > 4 || secondary_bps < 1 || secondary_bps > 4 || output_bps < 1 || output_bps > 4) {
+    return;
+  }
+
+  // Pick the aligned fast path if every pointer satisfies the strictest sample-width alignment in
+  // use across the three buffers; otherwise fall back to the byte-wise path.
+  const uintptr_t align_mask =
+      alignment_mask(primary_bps) | alignment_mask(secondary_bps) | alignment_mask(output_bps);
+  const uintptr_t ptr_or = reinterpret_cast<uintptr_t>(primary) | reinterpret_cast<uintptr_t>(secondary) |
+                           reinterpret_cast<uintptr_t>(output);
+  const bool aligned = (ptr_or & align_mask) == 0;
+
+  if (aligned) {
+    mix_frames_dispatch_primary<true>(primary_bps, secondary_bps, output_bps, primary, primary_channels, secondary,
+                                      secondary_channels, output, output_channels, frames);
+  } else {
+    mix_frames_dispatch_primary<false>(primary_bps, secondary_bps, output_bps, primary, primary_channels, secondary,
+                                       secondary_channels, output, output_channels, frames);
+  }
+}
+
+}  // namespace mixer
+}  // namespace esp_audio_libs

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -20,11 +20,13 @@ constexpr int32_t Q30_MIN = -(INT32_C(1) << 30);
 constexpr int32_t Q30_MAX = (INT32_C(1) << 30) - 1;
 
 // Sum two Q31 inputs into a saturated Q31 output. Each input is halved before adding so the sum
-// stays in int32; the result is clamped to the Q30 range and shifted back to Q31, which
-// preventsthe left shift from overflowing.
+// stays in int32; the result is clamped to the Q30 range and shifted back to Q31. The shift goes
+// through uint32_t because left-shifting a negative signed value is undefined before C++20; the
+// clamp guarantees the shifted result still fits in int32.
 EAL_HOT inline int32_t mix_q31(int32_t primary_q31, int32_t secondary_q31) {
   const int32_t sum_q30 = (primary_q31 >> 1) + (secondary_q31 >> 1);
-  return std::min(std::max(sum_q30, Q30_MIN), Q30_MAX) << 1;
+  const int32_t clamped_q30 = std::min(std::max(sum_q30, Q30_MIN), Q30_MAX);
+  return static_cast<int32_t>(static_cast<uint32_t>(clamped_q30) << 1);
 }
 
 // Pick the fast (aligned wide-load) or byte-wise variant at compile time. The `Aligned` template

--- a/src/pcm_convert.cpp
+++ b/src/pcm_convert.cpp
@@ -68,7 +68,9 @@ EAL_HOT void copy_frames_fixed_channels(const uint8_t *in_ptr, uint8_t *out_ptr,
 template<size_t InputBps, size_t OutputBps, bool Aligned>
 EAL_HOT void copy_frames_dispatch_channels(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_channels,
                                            uint8_t output_channels, uint32_t frames) {
-  // Fast paths for the common 1- and 2-channel configurations.
+  // Matching channel counts are rewritten to the 1->1 path by copy_frames(), so only the
+  // mismatched mono/stereo remaps need a fixed-channel specialization here. The 1->1 case still
+  // arrives via that rewrite (it carries frames*channels samples).
   if (output_channels == 1) {
     if (input_channels == 1)
       return copy_frames_fixed_channels<InputBps, OutputBps, 1, 1, Aligned>(in_ptr, out_ptr, frames);
@@ -77,10 +79,8 @@ EAL_HOT void copy_frames_dispatch_channels(const uint8_t *in_ptr, uint8_t *out_p
   } else if (output_channels == 2) {
     if (input_channels == 1)
       return copy_frames_fixed_channels<InputBps, OutputBps, 1, 2, Aligned>(in_ptr, out_ptr, frames);
-    if (input_channels == 2)
-      return copy_frames_fixed_channels<InputBps, OutputBps, 2, 2, Aligned>(in_ptr, out_ptr, frames);
   }
-  // Fallback for unusual channel counts (3+ channels in or out).
+  // Fallback for unusual channel remaps (3+ channels in or out, with differing counts).
   copy_frames_generic<InputBps, OutputBps, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
 }
 
@@ -141,6 +141,17 @@ void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8
   if (input_bps == output_bps && input_channels == output_channels) {
     std::memcpy(output, input, static_cast<size_t>(frames) * input_channels * input_bps);
     return;
+  }
+
+  // When the channel counts match, bit-depth conversion is purely per-sample and the interleaved
+  // channel layout is irrelevant: treat the buffers as a flat run of frames*channels mono samples
+  // and convert each independently. This lets every matching-channel case (including 3+ channels)
+  // reuse the unrolled 1->1 path instead of needing its own specialization or the generic loop.
+  // frames*channels stays within uint32_t under the documented byte-count-fits-size_t precondition.
+  if (input_channels == output_channels) {
+    frames *= input_channels;
+    input_channels = 1;
+    output_channels = 1;
   }
 
   // Pick the aligned fast path only if each buffer satisfies the alignment its own sample width

--- a/src/pcm_convert.cpp
+++ b/src/pcm_convert.cpp
@@ -147,7 +147,8 @@ void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8
   // channel layout is irrelevant: treat the buffers as a flat run of frames*channels mono samples
   // and convert each independently. This lets every matching-channel case (including 3+ channels)
   // reuse the unrolled 1->1 path instead of needing its own specialization or the generic loop.
-  // frames*channels stays within uint32_t under the documented byte-count-fits-size_t precondition.
+  // frames*channels stays within uint32_t by the documented precondition: on 32-bit targets it
+  // follows from the byte-count-fits-size_t rule; on 64-bit hosts the caller guarantees it directly.
   if (input_channels == output_channels) {
     frames *= input_channels;
     input_channels = 1;

--- a/src/pcm_convert.cpp
+++ b/src/pcm_convert.cpp
@@ -143,11 +143,10 @@ void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8
     return;
   }
 
-  // Pick the aligned fast path if both pointers satisfy the strictest sample-width alignment in
-  // use across the two buffers; otherwise fall back to the byte-wise path.
-  const uintptr_t align_mask = alignment_mask(input_bps) | alignment_mask(output_bps);
-  const uintptr_t ptr_or = reinterpret_cast<uintptr_t>(input) | reinterpret_cast<uintptr_t>(output);
-  const bool aligned = (ptr_or & align_mask) == 0;
+  // Pick the aligned fast path only if each buffer satisfies the alignment its own sample width
+  // requires; otherwise fall back to the byte-wise path.
+  const bool aligned = (reinterpret_cast<uintptr_t>(input) & alignment_mask(input_bps)) == 0 &&
+                       (reinterpret_cast<uintptr_t>(output) & alignment_mask(output_bps)) == 0;
 
   if (aligned) {
     copy_frames_dispatch_input<true>(input, output, input_bps, output_bps, input_channels, output_channels, frames);

--- a/src/pcm_convert.cpp
+++ b/src/pcm_convert.cpp
@@ -1,0 +1,160 @@
+#include "pcm_convert.h"
+
+#include <algorithm>
+#include <cstring>
+
+#include "compiler.h"
+#include "q31_utils.h"
+
+namespace esp_audio_libs {
+namespace pcm_convert {
+
+namespace {
+
+using internal::fast_pack_q31;
+using internal::fast_unpack_to_q31;
+using internal::pack_q31;
+using internal::unpack_to_q31;
+
+// Pick the fast (aligned wide-load) or byte-wise variant at compile time. The `Aligned` template
+// flag is set by the runtime alignment check in copy_frames(); both branches fold away at -O2.
+template<size_t Bps, bool Aligned> EAL_HOT inline int32_t unpack(const uint8_t *data) {
+  if (Aligned) {
+    return fast_unpack_to_q31<Bps>(data);
+  }
+  return unpack_to_q31<Bps>(data);
+}
+
+template<size_t Bps, bool Aligned> EAL_HOT inline void pack(int32_t sample, uint8_t *data) {
+  if (Aligned) {
+    fast_pack_q31<Bps>(sample, data);
+  } else {
+    pack_q31<Bps>(sample, data);
+  }
+}
+
+template<size_t InputBps, size_t OutputBps, bool Aligned>
+EAL_HOT void copy_frames_generic(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_channels,
+                                 uint8_t output_channels, uint32_t frames) {
+  const uint8_t max_input_channel_index = input_channels - 1;
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+      const uint8_t in_ch = std::min<uint8_t>(out_ch, max_input_channel_index);
+      const int32_t q31 = unpack<InputBps, Aligned>(in_ptr + in_ch * InputBps);
+      pack<OutputBps, Aligned>(q31, out_ptr + out_ch * OutputBps);
+    }
+    in_ptr += input_channels * InputBps;
+    out_ptr += output_channels * OutputBps;
+  }
+}
+
+// Channel-count-specialized variant. Hard-coding the channel counts lets the compiler unroll the
+// inner channel loop, leaving a single straight-line outer loop that Xtensa can lower to a
+// hardware zero-overhead loop (LOOPNEZ/LOOPGTZ).
+template<size_t InputBps, size_t OutputBps, uint8_t InputChannels, uint8_t OutputChannels, bool Aligned>
+EAL_HOT void copy_frames_fixed_channels(const uint8_t *in_ptr, uint8_t *out_ptr, uint32_t frames) {
+  constexpr uint8_t MAX_INPUT_CHANNEL_INDEX = InputChannels - 1;
+  for (uint32_t frame = 0; frame < frames; ++frame) {
+    for (uint8_t out_ch = 0; out_ch < OutputChannels; ++out_ch) {
+      const uint8_t in_ch = std::min<uint8_t>(out_ch, MAX_INPUT_CHANNEL_INDEX);
+      const int32_t q31 = unpack<InputBps, Aligned>(in_ptr + in_ch * InputBps);
+      pack<OutputBps, Aligned>(q31, out_ptr + out_ch * OutputBps);
+    }
+    in_ptr += InputChannels * InputBps;
+    out_ptr += OutputChannels * OutputBps;
+  }
+}
+
+template<size_t InputBps, size_t OutputBps, bool Aligned>
+EAL_HOT void copy_frames_dispatch_channels(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_channels,
+                                           uint8_t output_channels, uint32_t frames) {
+  // Fast paths for the common 1- and 2-channel configurations.
+  if (output_channels == 1) {
+    if (input_channels == 1)
+      return copy_frames_fixed_channels<InputBps, OutputBps, 1, 1, Aligned>(in_ptr, out_ptr, frames);
+    if (input_channels == 2)
+      return copy_frames_fixed_channels<InputBps, OutputBps, 2, 1, Aligned>(in_ptr, out_ptr, frames);
+  } else if (output_channels == 2) {
+    if (input_channels == 1)
+      return copy_frames_fixed_channels<InputBps, OutputBps, 1, 2, Aligned>(in_ptr, out_ptr, frames);
+    if (input_channels == 2)
+      return copy_frames_fixed_channels<InputBps, OutputBps, 2, 2, Aligned>(in_ptr, out_ptr, frames);
+  }
+  // Fallback for unusual channel counts (3+ channels in or out).
+  copy_frames_generic<InputBps, OutputBps, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+}
+
+template<size_t InputBps, bool Aligned>
+void copy_frames_dispatch_output(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t output_bps, uint8_t input_channels,
+                                 uint8_t output_channels, uint32_t frames) {
+  switch (output_bps) {
+    case 1:
+      copy_frames_dispatch_channels<InputBps, 1, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      break;
+    case 2:
+      copy_frames_dispatch_channels<InputBps, 2, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      break;
+    case 3:
+      copy_frames_dispatch_channels<InputBps, 3, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      break;
+    case 4:
+      copy_frames_dispatch_channels<InputBps, 4, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      break;
+  }
+}
+
+template<bool Aligned>
+void copy_frames_dispatch_input(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_bps, uint8_t output_bps,
+                                uint8_t input_channels, uint8_t output_channels, uint32_t frames) {
+  switch (input_bps) {
+    case 1:
+      copy_frames_dispatch_output<1, Aligned>(in_ptr, out_ptr, output_bps, input_channels, output_channels, frames);
+      break;
+    case 2:
+      copy_frames_dispatch_output<2, Aligned>(in_ptr, out_ptr, output_bps, input_channels, output_channels, frames);
+      break;
+    case 3:
+      copy_frames_dispatch_output<3, Aligned>(in_ptr, out_ptr, output_bps, input_channels, output_channels, frames);
+      break;
+    case 4:
+      copy_frames_dispatch_output<4, Aligned>(in_ptr, out_ptr, output_bps, input_channels, output_channels, frames);
+      break;
+  }
+}
+
+// Required alignment for a sample width: 2 bytes for 16-bit (mask 0x1), 4 bytes for 32-bit (mask
+// 0x3). 1- and 3-byte widths are byte-wise and have no alignment requirement.
+inline uintptr_t alignment_mask(uint8_t bps) {
+  if (bps == 2) return 0x1;
+  if (bps == 4) return 0x3;
+  return 0;
+}
+
+}  // namespace
+
+void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8_t input_channels, uint8_t output_bps,
+                 uint8_t output_channels, uint32_t frames) {
+  if (frames == 0 || input_bps < 1 || input_bps > 4 || output_bps < 1 || output_bps > 4) {
+    return;
+  }
+
+  if (input_bps == output_bps && input_channels == output_channels) {
+    std::memcpy(output, input, static_cast<size_t>(frames) * input_channels * input_bps);
+    return;
+  }
+
+  // Pick the aligned fast path if both pointers satisfy the strictest sample-width alignment in
+  // use across the two buffers; otherwise fall back to the byte-wise path.
+  const uintptr_t align_mask = alignment_mask(input_bps) | alignment_mask(output_bps);
+  const uintptr_t ptr_or = reinterpret_cast<uintptr_t>(input) | reinterpret_cast<uintptr_t>(output);
+  const bool aligned = (ptr_or & align_mask) == 0;
+
+  if (aligned) {
+    copy_frames_dispatch_input<true>(input, output, input_bps, output_bps, input_channels, output_channels, frames);
+  } else {
+    copy_frames_dispatch_input<false>(input, output, input_bps, output_bps, input_channels, output_channels, frames);
+  }
+}
+
+}  // namespace pcm_convert
+}  // namespace esp_audio_libs

--- a/src/pcm_convert.cpp
+++ b/src/pcm_convert.cpp
@@ -134,7 +134,8 @@ inline uintptr_t alignment_mask(uint8_t bps) {
 
 void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8_t input_channels, uint8_t output_bps,
                  uint8_t output_channels, uint32_t frames) {
-  if (frames == 0 || input_bps < 1 || input_bps > 4 || output_bps < 1 || output_bps > 4) {
+  if (frames == 0 || input_channels == 0 || output_channels == 0 || input_bps < 1 || input_bps > 4 ||
+      output_bps < 1 || output_bps > 4) {
     return;
   }
 

--- a/src/q31_utils.h
+++ b/src/q31_utils.h
@@ -1,0 +1,112 @@
+#pragma once
+
+/// @file q31_utils.h
+/// @brief Templated PCM sample <-> Q31 pack/unpack helpers (private to esp-audio-libs).
+///
+/// A sample of `Bps` bytes is represented as an int32 with the sample value left-justified into
+/// the most significant bits (Q31 form), sign extended. This is the common intermediate format
+/// used by the mixer and PCM format-conversion code. The `Bps` template parameter is always a
+/// compile-time constant here, so the per-width branches below fold away at -O2.
+///
+/// All pack/unpack functions assume little-endian byte order in the audio buffer.
+
+#include <cstddef>
+#include <cstdint>
+
+#include "compiler.h"
+
+namespace esp_audio_libs {
+namespace internal {
+
+/// @brief Loads a sample of `Bps` bytes (little-endian, signed) into Q31 form.
+///
+/// The sample value is left-justified into the most significant bits of an int32, with sign
+/// extension. Byte-wise access, so safe for any pointer alignment.
+/// @tparam Bps Sample width in bytes: 1, 2, 3, or 4.
+/// @param data Pointer to the first byte of the sample.
+/// @return Q31 sample value.
+template<size_t Bps> inline int32_t unpack_to_q31(const uint8_t *data) {
+  static_assert(Bps >= 1 && Bps <= 4, "Bps must be 1, 2, 3, or 4");
+  if (Bps == 1) {
+    return static_cast<int32_t>(static_cast<uint32_t>(data[0]) << 24);
+  } else if (Bps == 2) {
+    return static_cast<int32_t>((static_cast<uint32_t>(data[0]) << 16) | (static_cast<uint32_t>(data[1]) << 24));
+  } else if (Bps == 3) {
+    return static_cast<int32_t>((static_cast<uint32_t>(data[0]) << 8) | (static_cast<uint32_t>(data[1]) << 16) |
+                                (static_cast<uint32_t>(data[2]) << 24));
+  } else {
+    return static_cast<int32_t>(static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
+                                (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24));
+  }
+}
+
+/// @brief Stores the most significant `Bps` bytes of a Q31 sample as little-endian PCM.
+///
+/// Byte-wise access, so safe for any pointer alignment. The caller is responsible for adding any
+/// rounding term to `sample` before calling.
+/// @tparam Bps Sample width in bytes: 1, 2, 3, or 4.
+/// @param sample Q31 sample to store.
+/// @param data Pointer to the first byte to write.
+template<size_t Bps> inline void pack_q31(int32_t sample, uint8_t *data) {
+  static_assert(Bps >= 1 && Bps <= 4, "Bps must be 1, 2, 3, or 4");
+  if (Bps == 1) {
+    data[0] = static_cast<uint8_t>(sample >> 24);
+  } else if (Bps == 2) {
+    data[0] = static_cast<uint8_t>(sample >> 16);
+    data[1] = static_cast<uint8_t>(sample >> 24);
+  } else if (Bps == 3) {
+    data[0] = static_cast<uint8_t>(sample >> 8);
+    data[1] = static_cast<uint8_t>(sample >> 16);
+    data[2] = static_cast<uint8_t>(sample >> 24);
+  } else {
+    data[0] = static_cast<uint8_t>(sample);
+    data[1] = static_cast<uint8_t>(sample >> 8);
+    data[2] = static_cast<uint8_t>(sample >> 16);
+    data[3] = static_cast<uint8_t>(sample >> 24);
+  }
+}
+
+/// @brief Like unpack_to_q31, but issues a single wide load for the 16- and 32-bit cases.
+///
+/// Requires `data` to be aligned to `Bps` for the 2- and 4-byte cases. The 1- and 3-byte cases
+/// have no alignment requirement and fall through to the byte-wise path.
+/// @tparam Bps Sample width in bytes: 1, 2, 3, or 4.
+/// @param data Pointer to the first byte of the sample. Must be aligned to `Bps` for Bps == 2 or 4.
+/// @return Q31 sample value.
+template<size_t Bps> inline int32_t fast_unpack_to_q31(const uint8_t *data) {
+  static_assert(Bps >= 1 && Bps <= 4, "Bps must be 1, 2, 3, or 4");
+  if (Bps == 2) {
+    int16_t v;
+    EAL_MEMCPY(&v, EAL_ASSUME_ALIGNED(data, 2), sizeof(int16_t));
+    // Cast to uint16_t first to suppress sign-extension before shifting into Q31.
+    return static_cast<int32_t>(static_cast<uint32_t>(static_cast<uint16_t>(v)) << 16);
+  } else if (Bps == 4) {
+    int32_t v;
+    EAL_MEMCPY(&v, EAL_ASSUME_ALIGNED(data, 4), sizeof(int32_t));
+    return v;
+  } else {
+    return unpack_to_q31<Bps>(data);
+  }
+}
+
+/// @brief Like pack_q31, but issues a single wide store for the 16- and 32-bit cases.
+///
+/// Requires `data` to be aligned to `Bps` for the 2- and 4-byte cases. The 1- and 3-byte cases
+/// have no alignment requirement and fall through to the byte-wise path.
+/// @tparam Bps Sample width in bytes: 1, 2, 3, or 4.
+/// @param sample Q31 sample to store.
+/// @param data Pointer to the first byte to write. Must be aligned to `Bps` for Bps == 2 or 4.
+template<size_t Bps> inline void fast_pack_q31(int32_t sample, uint8_t *data) {
+  static_assert(Bps >= 1 && Bps <= 4, "Bps must be 1, 2, 3, or 4");
+  if (Bps == 2) {
+    int16_t v = static_cast<int16_t>(sample >> 16);
+    EAL_MEMCPY(EAL_ASSUME_ALIGNED(data, 2), &v, sizeof(int16_t));
+  } else if (Bps == 4) {
+    EAL_MEMCPY(EAL_ASSUME_ALIGNED(data, 4), &sample, sizeof(int32_t));
+  } else {
+    pack_q31<Bps>(sample, data);
+  }
+}
+
+}  // namespace internal
+}  // namespace esp_audio_libs


### PR DESCRIPTION
Adds helper functions to support the `mixer` speaker component in ESPHome that can combine multiple audio streams into one; e.g., mix an announcement and music together.

- Adds Q31 pack/unpack methods (aligned and unaligned) as internal header
- Updates `gain` functions to use the new pack/unpack methods
- Adds audio ducking helper methods
- Adds PCM conversion methods that handle channel and bit-depth conversions
- Add PCM mixing methods that handle channel and bit-depth conversions

Bit-depth conversion truncate when reducing width; these should primarily be used for increasing width if you care about audio quality! 

Channel conversions duplicate the last channel or drops the extra channels to match; it these should primarily be used for mono->stereo conversions where duplication is the desired behavior!