### PR TITLE
Optimize PCM convert and mix paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,11 @@ dist/
 
 flac_to_wav
 !flac_to_wav/
+
+# PlatformIO / ESP-IDF example build output
+.pio/
+examples/**/sdkconfig
+examples/**/sdkconfig.old
+examples/**/dependencies.lock
+examples/**/managed_components/
+examples/**/sdkconfig.esp32*

--- a/examples/pcm_benchmark/CMakeLists.txt
+++ b/examples/pcm_benchmark/CMakeLists.txt
@@ -1,0 +1,9 @@
+# esp-audio-libs PCM convert / mixer benchmark example
+
+cmake_minimum_required(VERSION 3.16)
+
+# Include the esp-audio-libs component from the repository root (two levels up).
+list(APPEND EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../..")
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(pcm_benchmark)

--- a/examples/pcm_benchmark/README.md
+++ b/examples/pcm_benchmark/README.md
@@ -1,0 +1,77 @@
+# PCM Convert / Mixer / Gain Benchmark
+
+Benchmarks `pcm_convert::copy_frames`, `mixer::mix_frames`, and `gain::apply` across a matrix of formats: different input and output bit depths (1, 2, 3, 4 bytes per sample) and, for convert and mix, different channel counts (mono and stereo, including up-mix and down-mix). The gain pass adds in-place and out-of-place variants per bit depth. The input is synthetic PCM generated at runtime, so this is a pure CPU throughput test of the kernels with no embedded audio asset.
+
+## Building and Flashing
+
+### Prerequisites
+
+- **PlatformIO** (recommended) OR ESP-IDF v5.0 or later
+- Any ESP32 development board (the benchmark keeps its buffers in internal RAM, so PSRAM is not required)
+
+### Option 1: PlatformIO (Recommended)
+
+```bash
+cd examples/pcm_benchmark
+
+# Build, upload, and monitor (ESP32-S3)
+pio run -e esp32s3 -t upload -t monitor
+
+# Or target a plain ESP32
+pio run -e esp32 -t upload -t monitor
+```
+
+The PlatformIO configuration pulls in the parent esp-audio-libs repository as a component, so no additional setup is required.
+
+### Option 2: Native ESP-IDF
+
+```bash
+cd examples/pcm_benchmark
+idf.py set-target esp32s3
+idf.py build
+idf.py flash monitor
+```
+
+## Configuration Options
+
+The benchmark dimensions are compile-time defines (override them with `build_flags` in `platformio.ini` or `-D` in ESP-IDF):
+
+| Define | Default | Meaning |
+| ------ | ------- | ------- |
+| `PCM_BENCH_FRAMES` | 1024 | Frames processed per library call |
+| `PCM_BENCH_BATCH` | 32 | Calls timed together as one measurement sample |
+| `PCM_BENCH_SAMPLES` | 50 | Measurement samples collected per scenario |
+
+To benchmark different formats, edit the `CONVERT_SCENARIOS`, `MIX_SCENARIOS`, and `GAIN_SCENARIOS` tables near the top of `src/pcm_benchmark.cpp`. Convert and mix entries are `{bps, channels}` sets; gain entries are `{bps, in_place}`. Bit depth is in bytes (1, 2, 3, 4).
+
+## Expected Output
+
+Each iteration prints one line per scenario, for both alignment cases:
+
+```text
+I (310) PCM_BENCH: --- pcm_convert::copy_frames ---
+I (330) PCM_BENCH: CONV 2b2 -> 2b2 (copy)      aligned     10.86 ns/frame     736.7 MB/s      1918x RT  (min 10.83 max 11.05 sd 0.04)
+I (350) PCM_BENCH: CONV 2b2 -> 2b2 (copy)      misaligned  10.95 ns/frame     730.5 MB/s      1902x RT  (min 10.93 max 11.14 sd 0.04)
+I (400) PCM_BENCH: CONV 2b2 -> 4b2 (widen)     aligned     28.72 ns/frame     417.9 MB/s       725x RT  (min 28.69 max 28.90 sd 0.06)
+I (580) PCM_BENCH: CONV 2b2 -> 4b2 (widen)     misaligned 108.82 ns/frame     110.3 MB/s       191x RT  (min 108.73 max 108.95 sd 0.09)
+...
+I (2310) PCM_BENCH: --- mixer::mix_frames ---
+I (2480) PCM_BENCH: MIX  2b2 + 2b2 -> 2b2       aligned    100.72 ns/frame     119.1 MB/s       207x RT  (min 100.65 max 100.86 sd 0.09)
+...
+I (6760) PCM_BENCH: --- gain::apply ---
+I (6810) PCM_BENCH: GAIN 2b out-of-place        aligned     27.32 ns/sample    146.4 MB/s       763x RT  (min 27.28 max 27.50 sd 0.06)
+I (6930) PCM_BENCH: GAIN 2b out-of-place        misaligned  75.22 ns/sample     53.2 MB/s       277x RT  (min 75.16 max 75.38 sd 0.08)
+```
+
+Columns: kind (`CONV`/`MIX`/`GAIN`), format (`<bps>b<channels>`; e.g., `2b2` is 16-bit stereo, with input(s) → output), alignment, ns/frame (ns/sample for gain, which has no channel concept; lower is better), MB/s of read+write traffic, xRT@48k (how many 48 kHz streams one core could sustain on this op alone), and the per-sample min/max/sd spread.
+
+## How It Works
+
+Three 16-byte-aligned buffers (two inputs, one output) are filled with a deterministic pseudo-random pattern; the sample values do not affect timing. Each scenario calls the kernel `PCM_BENCH_BATCH` times back-to-back, timed as a unit with `esp_timer_get_time()` to stay well above the 1 µs timer resolution, and `PCM_BENCH_SAMPLES` such batches give the min/max/avg/sd spread. The misaligned variant offsets every pointer by one byte to force the byte-wise path.
+
+## Interpreting the Results
+
+- The `aligned` rows reflect the wide-load fast path that the library takes when each pointer is aligned to its sample width (2 bytes for 16-bit, 4 bytes for 32-bit). The `misaligned` rows show the byte-wise fallback. The gap is the value of keeping your audio buffers aligned.
+- Bit-depth conversion goes through a Q31 intermediate, so widening (e.g. 16→32) is exact while narrowing rounds the low bits. The identity case (matching bit depth and channel count) degenerates to a `memcpy` and is the fastest convert scenario.
+- Mixing sums two streams in Q29, so `mix_frames` does roughly twice the input traffic of a convert and lands slower per frame.
+- Gain multiplies each sample by a Q31 scale factor (1, 2, and 3 byte widths round; the 4 byte width truncates). It touches a single sample per unit, so its ns/sample numbers are not directly comparable to the per-frame convert/mix numbers; e.g., a stereo frame is two samples. In-place and out-of-place perform the same arithmetic; any difference is purely memory traffic (one buffer touched versus two).

--- a/examples/pcm_benchmark/platformio.ini
+++ b/examples/pcm_benchmark/platformio.ini
@@ -1,0 +1,11 @@
+[env]
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/54.03.20/platform-espressif32.zip
+framework = espidf
+monitor_speed = 115200
+
+[env:esp32s3]
+board = esp32-s3-devkitm-1
+upload_protocol = esp-builtin
+
+[env:esp32]
+board = esp32dev

--- a/examples/pcm_benchmark/sdkconfig.defaults
+++ b/examples/pcm_benchmark/sdkconfig.defaults
@@ -1,0 +1,13 @@
+# Common defaults for all targets.
+# Target-specific overrides live in sdkconfig.defaults.<target>.
+
+# Disable the task watchdog: the benchmark loops continuously in app_main.
+CONFIG_ESP_TASK_WDT_EN=n
+CONFIG_ESP_TASK_WDT_INIT=n
+
+# Run the CPU at its maximum frequency.
+CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y
+
+# Optimize the benchmark translation unit for performance. (The library applies
+# its own -O2 internally regardless of this setting.)
+CONFIG_COMPILER_OPTIMIZATION_PERF=y

--- a/examples/pcm_benchmark/sdkconfig.defaults.esp32
+++ b/examples/pcm_benchmark/sdkconfig.defaults.esp32
@@ -1,0 +1,5 @@
+# Plain ESP32 specific overrides.
+#
+# The benchmark keeps its working buffers in internal RAM, so no PSRAM is
+# required. This file is intentionally minimal; the common defaults already
+# select 240 MHz and the performance optimization level.

--- a/examples/pcm_benchmark/sdkconfig.defaults.esp32s3
+++ b/examples/pcm_benchmark/sdkconfig.defaults.esp32s3
@@ -1,0 +1,6 @@
+# ESP32-S3 specific overrides.
+
+# Use large data and instruction caches for steady-state throughput.
+CONFIG_ESP32S3_DATA_CACHE_64KB=y
+CONFIG_ESP32S3_DATA_CACHE_LINE_64B=y
+CONFIG_ESP32S3_INSTRUCTION_CACHE_32KB=y

--- a/examples/pcm_benchmark/src/CMakeLists.txt
+++ b/examples/pcm_benchmark/src/CMakeLists.txt
@@ -1,0 +1,3 @@
+idf_component_register(
+    SRCS "pcm_benchmark.cpp"
+    REQUIRES esp_timer esp-audio-libs)

--- a/examples/pcm_benchmark/src/pcm_benchmark.cpp
+++ b/examples/pcm_benchmark/src/pcm_benchmark.cpp
@@ -1,0 +1,369 @@
+// Copyright 2026 Kevin Ahrendt
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* esp-audio-libs PCM convert / mixer benchmark
+ *
+ * Measures the throughput of pcm_convert::copy_frames and mixer::mix_frames
+ * across a matrix of formats: different input/output bit depths (1, 2, 3, 4
+ * bytes per sample) and different channel counts (mono <-> stereo up/down mix).
+ *
+ * The input is synthetic PCM generated at runtime (a cheap pseudo-random fill),
+ * so the example needs no embedded audio asset -- this is a pure CPU throughput
+ * test of the conversion kernels, not a decode test.
+ *
+ * Each scenario is run twice: once on buffers aligned to their sample width
+ * (the documented wide-load fast path on Xtensa) and once on deliberately
+ * misaligned buffers (the byte-wise fallback), so the cost of the alignment
+ * dispatch is visible directly.
+ *
+ * Buffers live in internal RAM. They are small enough to stay resident in the
+ * data cache, so running them from PSRAM would mostly measure cache behavior
+ * rather than the external bus -- not a meaningful comparison, so it is omitted.
+ */
+
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "gain.h"
+#include "mixer.h"
+#include "pcm_convert.h"
+
+#include <cinttypes>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+static const char *const TAG = "PCM_BENCH";
+
+// Frames processed per library call. Sized like a typical audio chunk.
+#ifndef PCM_BENCH_FRAMES
+#define PCM_BENCH_FRAMES 1024
+#endif
+
+// Library calls timed together as one measurement sample. Batching keeps each
+// measured interval well above the 1 us esp_timer resolution.
+#ifndef PCM_BENCH_BATCH
+#define PCM_BENCH_BATCH 32
+#endif
+
+// Number of measurement samples collected per scenario (for min/max/avg/sd).
+#ifndef PCM_BENCH_SAMPLES
+#define PCM_BENCH_SAMPLES 50
+#endif
+
+static const uint32_t FRAMES = PCM_BENCH_FRAMES;
+static const int BATCH = PCM_BENCH_BATCH;
+static const int SAMPLES = PCM_BENCH_SAMPLES;
+
+// Sample rate used only to express throughput as a real-time factor.
+static const double REFERENCE_SAMPLE_RATE = 48000.0;
+
+// Widest single-buffer frame: 2 channels * 4 bytes. The +64 tail leaves room
+// for the 1-byte offset used to force the misaligned fallback path.
+static const size_t MAX_BYTES_PER_FRAME = 2 * 4;
+static const size_t BUFFER_BYTES = FRAMES * MAX_BYTES_PER_FRAME + 64;
+
+namespace pcm_convert = esp_audio_libs::pcm_convert;
+namespace mixer = esp_audio_libs::mixer;
+namespace gain = esp_audio_libs::gain;
+
+// Three aligned working buffers: two inputs (primary/secondary or convert
+// source) and one output. Allocated from internal RAM so PSRAM cache misses
+// do not contaminate the kernel timings.
+static uint8_t *g_in_a = nullptr;
+static uint8_t *g_in_b = nullptr;
+static uint8_t *g_out = nullptr;
+
+// ---------------------------------------------------------------------------
+// Statistics over per-frame timings (nanoseconds)
+// ---------------------------------------------------------------------------
+
+struct Stats {
+  double min_ns;
+  double max_ns;
+  double sum_ns;
+  double sum_sq_ns;
+  int count;
+};
+
+static void init_stats(Stats *s) {
+  s->min_ns = 1e30;
+  s->max_ns = 0.0;
+  s->sum_ns = 0.0;
+  s->sum_sq_ns = 0.0;
+  s->count = 0;
+}
+
+static void update_stats(Stats *s, double ns) {
+  if (ns < s->min_ns) {
+    s->min_ns = ns;
+  }
+  if (ns > s->max_ns) {
+    s->max_ns = ns;
+  }
+  s->sum_ns += ns;
+  s->sum_sq_ns += ns * ns;
+  s->count++;
+}
+
+// Log one scenario's result: average ns per unit, throughput, real-time factor,
+// and the per-sample min/max/sd spread.
+//
+// The unit is a frame for convert/mix and a single sample for gain (gain has no
+// channel concept). bytes_per_unit counts both reads and writes (input
+// footprint + output footprint), so MB/s reflects total memory traffic moved.
+static void log_result(const char *kind, const char *name, const char *align, const char *unit,
+                       const Stats *s, double bytes_per_unit) {
+  if (s->count == 0) {
+    ESP_LOGI(TAG, "%s %-22s %-10s no data", kind, name, align);
+    return;
+  }
+
+  double avg = s->sum_ns / s->count;
+  double variance = s->sum_sq_ns / s->count - avg * avg;
+  double sd = variance > 0.0 ? sqrt(variance) : 0.0;
+
+  double units_per_sec = avg > 0.0 ? 1e9 / avg : 0.0;
+  double mb_per_sec = avg > 0.0 ? bytes_per_unit * 1000.0 / avg : 0.0;
+  double realtime_x = units_per_sec / REFERENCE_SAMPLE_RATE;
+
+  ESP_LOGI(TAG, "%s %-22s %-10s %6.2f ns/%-7s %7.1f MB/s  %8.0fx RT  (min %.2f max %.2f sd %.2f)",
+           kind, name, align, avg, unit, mb_per_sec, realtime_x, s->min_ns, s->max_ns, sd);
+}
+
+// ---------------------------------------------------------------------------
+// Scenario tables
+// ---------------------------------------------------------------------------
+
+struct ConvertScenario {
+  const char *name;
+  uint8_t in_bps;
+  uint8_t in_ch;
+  uint8_t out_bps;
+  uint8_t out_ch;
+};
+
+// bps in bytes (1/2/3/4), ch in channels. Names use the "<bps>b<ch>" shorthand.
+static const ConvertScenario CONVERT_SCENARIOS[] = {
+    {"2b2 -> 2b2 (copy)", 2, 2, 2, 2},   {"2b2 -> 4b2 (widen)", 2, 2, 4, 2},
+    {"4b2 -> 2b2 (narrow)", 4, 2, 2, 2}, {"3b2 -> 2b2", 3, 2, 2, 2},
+    {"2b2 -> 3b2", 2, 2, 3, 2},          {"1b2 -> 2b2", 1, 2, 2, 2},
+    {"2b1 -> 2b2 (upmix)", 2, 1, 2, 2},  {"2b2 -> 2b1 (downmix)", 2, 2, 2, 1},
+    {"2b1 -> 4b2", 2, 1, 4, 2},
+};
+static const int NUM_CONVERT_SCENARIOS = sizeof(CONVERT_SCENARIOS) / sizeof(CONVERT_SCENARIOS[0]);
+
+struct MixScenario {
+  const char *name;
+  uint8_t pri_bps;
+  uint8_t pri_ch;
+  uint8_t sec_bps;
+  uint8_t sec_ch;
+  uint8_t out_bps;
+  uint8_t out_ch;
+};
+
+static const MixScenario MIX_SCENARIOS[] = {
+    {"2b2 + 2b2 -> 2b2", 2, 2, 2, 2, 2, 2}, {"2b2 + 2b1 -> 2b2", 2, 2, 2, 1, 2, 2},
+    {"4b2 + 2b2 -> 4b2", 4, 2, 2, 2, 4, 2}, {"3b2 + 3b2 -> 3b2", 3, 2, 3, 2, 3, 2},
+    {"2b1 + 2b1 -> 2b1", 2, 1, 2, 1, 2, 1}, {"2b2 + 4b2 -> 2b2", 2, 2, 4, 2, 2, 2},
+};
+static const int NUM_MIX_SCENARIOS = sizeof(MIX_SCENARIOS) / sizeof(MIX_SCENARIOS[0]);
+
+// gain::apply works on a flat run of samples and has no channel concept, so a
+// scenario is just a sample width plus whether the call is in-place (output ==
+// input) or out-of-place. The aligned/misaligned variants are added by the
+// runner, exercising the wide-load fast path versus the byte-wise fallback.
+struct GainScenario {
+  const char *name;
+  uint8_t bps;
+  bool in_place;
+};
+
+static const GainScenario GAIN_SCENARIOS[] = {
+    {"2b out-of-place", 2, false}, {"3b out-of-place", 3, false}, {"4b out-of-place", 4, false},
+    {"2b in-place", 2, true},      {"3b in-place", 3, true},      {"4b in-place", 4, true},
+};
+static const int NUM_GAIN_SCENARIOS = sizeof(GAIN_SCENARIOS) / sizeof(GAIN_SCENARIOS[0]);
+
+// ---------------------------------------------------------------------------
+// Benchmark runners
+// ---------------------------------------------------------------------------
+
+// One measurement sample = BATCH back-to-back kernel calls, timed together.
+// The reported ns/frame is averaged across all calls in all samples.
+static void run_convert(const ConvertScenario &s, bool misaligned) {
+  size_t off = misaligned ? 1 : 0;
+  const uint8_t *in = g_in_a + off;
+  uint8_t *out = g_out + off;
+
+  // Warm caches / branch predictors before timing.
+  for (int w = 0; w < 4; w++) {
+    pcm_convert::copy_frames(in, out, s.in_bps, s.in_ch, s.out_bps, s.out_ch, FRAMES);
+  }
+
+  Stats st;
+  init_stats(&st);
+  for (int sample = 0; sample < SAMPLES; sample++) {
+    int64_t t0 = esp_timer_get_time();
+    for (int b = 0; b < BATCH; b++) {
+      pcm_convert::copy_frames(in, out, s.in_bps, s.in_ch, s.out_bps, s.out_ch, FRAMES);
+    }
+    int64_t dt_us = esp_timer_get_time() - t0;
+    double ns_per_frame = (double)dt_us * 1000.0 / ((double)BATCH * (double)FRAMES);
+    update_stats(&st, ns_per_frame);
+  }
+
+  double bytes_per_frame = (double)s.in_bps * s.in_ch + (double)s.out_bps * s.out_ch;
+  log_result("CONV", s.name, misaligned ? "misaligned" : "aligned", "frame", &st, bytes_per_frame);
+}
+
+static void run_mix(const MixScenario &s, bool misaligned) {
+  size_t off = misaligned ? 1 : 0;
+  const uint8_t *pri = g_in_a + off;
+  const uint8_t *sec = g_in_b + off;
+  uint8_t *out = g_out + off;
+
+  for (int w = 0; w < 4; w++) {
+    mixer::mix_frames(pri, s.pri_bps, s.pri_ch, sec, s.sec_bps, s.sec_ch, out, s.out_bps, s.out_ch,
+                      FRAMES);
+  }
+
+  Stats st;
+  init_stats(&st);
+  for (int sample = 0; sample < SAMPLES; sample++) {
+    int64_t t0 = esp_timer_get_time();
+    for (int b = 0; b < BATCH; b++) {
+      mixer::mix_frames(pri, s.pri_bps, s.pri_ch, sec, s.sec_bps, s.sec_ch, out, s.out_bps,
+                        s.out_ch, FRAMES);
+    }
+    int64_t dt_us = esp_timer_get_time() - t0;
+    double ns_per_frame = (double)dt_us * 1000.0 / ((double)BATCH * (double)FRAMES);
+    update_stats(&st, ns_per_frame);
+  }
+
+  double bytes_per_frame = (double)s.pri_bps * s.pri_ch + (double)s.sec_bps * s.sec_ch +
+                           (double)s.out_bps * s.out_ch;
+  log_result("MIX ", s.name, misaligned ? "misaligned" : "aligned", "frame", &st, bytes_per_frame);
+}
+
+// gain::apply scales a flat run of FRAMES samples. A representative non-unity
+// scale (-6 dB) is used so the kernel does real multiply/round work; the exact
+// value does not affect timing. For the in-place case the buffer is also the
+// output, so repeated calls drive the samples toward zero -- harmless here since
+// the conversion math has no zero special-casing.
+static void run_gain(const GainScenario &s, bool misaligned) {
+  static const int32_t q31_scale = gain::db_to_q31(-6.0f);
+  size_t off = misaligned ? 1 : 0;
+  const uint8_t *in = g_in_a + off;
+  uint8_t *out = s.in_place ? (g_in_a + off) : (g_out + off);
+
+  for (int w = 0; w < 4; w++) {
+    gain::apply(in, out, q31_scale, FRAMES, s.bps);
+  }
+
+  Stats st;
+  init_stats(&st);
+  for (int sample = 0; sample < SAMPLES; sample++) {
+    int64_t t0 = esp_timer_get_time();
+    for (int b = 0; b < BATCH; b++) {
+      gain::apply(in, out, q31_scale, FRAMES, s.bps);
+    }
+    int64_t dt_us = esp_timer_get_time() - t0;
+    double ns_per_sample = (double)dt_us * 1000.0 / ((double)BATCH * (double)FRAMES);
+    update_stats(&st, ns_per_sample);
+  }
+
+  // One read plus one write of the sample, regardless of in-place vs not.
+  double bytes_per_sample = 2.0 * (double)s.bps;
+  log_result("GAIN", s.name, misaligned ? "misaligned" : "aligned", "sample", &st, bytes_per_sample);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+// Fill a buffer with a deterministic pseudo-random pattern. Real data is
+// irrelevant to timing; a varied bit pattern just avoids any denormal/zero
+// special-casing in the conversion math.
+static void fill_pattern(uint8_t *buf, size_t bytes, uint32_t seed) {
+  uint32_t state = seed;
+  for (size_t i = 0; i < bytes; i++) {
+    state = state * 1664525u + 1013904223u;  // Numerical Recipes LCG
+    buf[i] = (uint8_t)(state >> 24);
+  }
+}
+
+static bool alloc_buffers() {
+  uint32_t caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+  g_in_a = (uint8_t *)heap_caps_aligned_alloc(16, BUFFER_BYTES, caps);
+  g_in_b = (uint8_t *)heap_caps_aligned_alloc(16, BUFFER_BYTES, caps);
+  g_out = (uint8_t *)heap_caps_aligned_alloc(16, BUFFER_BYTES, caps);
+  if (g_in_a == nullptr || g_in_b == nullptr || g_out == nullptr) {
+    return false;
+  }
+  fill_pattern(g_in_a, BUFFER_BYTES, 0x12345678u);
+  fill_pattern(g_in_b, BUFFER_BYTES, 0x9abcdef0u);
+  memset(g_out, 0, BUFFER_BYTES);
+  return true;
+}
+
+extern "C" void app_main(void) {
+  ESP_LOGI(TAG, "=== esp-audio-libs PCM convert / mixer benchmark ===");
+  ESP_LOGI(TAG, "Frames/call: %lu   Batch: %d   Samples: %d", (unsigned long)FRAMES, BATCH, SAMPLES);
+  ESP_LOGI(TAG, "Free internal: %zu bytes", heap_caps_get_free_size(MALLOC_CAP_INTERNAL));
+
+  if (!alloc_buffers()) {
+    ESP_LOGE(TAG, "Failed to allocate benchmark buffers (%zu bytes x3)", BUFFER_BYTES);
+    return;
+  }
+
+  ESP_LOGI(TAG, "Columns: <kind> <format> <alignment> <ns/frame> <MB/s> <xRT@48k> (per-sample spread)");
+  ESP_LOGI(TAG, "  ns/frame: lower is better.  MB/s: total read+write traffic.");
+  ESP_LOGI(TAG, "  xRT@48k: how many 48 kHz streams one core could sustain on this op alone.");
+
+  uint32_t iteration = 0;
+  while (true) {
+    iteration++;
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "=== Iteration %lu ===", (unsigned long)iteration);
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "--- pcm_convert::copy_frames ---");
+    for (int i = 0; i < NUM_CONVERT_SCENARIOS; i++) {
+      run_convert(CONVERT_SCENARIOS[i], false);
+      run_convert(CONVERT_SCENARIOS[i], true);
+    }
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "--- mixer::mix_frames ---");
+    for (int i = 0; i < NUM_MIX_SCENARIOS; i++) {
+      run_mix(MIX_SCENARIOS[i], false);
+      run_mix(MIX_SCENARIOS[i], true);
+    }
+
+    ESP_LOGI(TAG, "");
+    ESP_LOGI(TAG, "--- gain::apply ---");
+    for (int i = 0; i < NUM_GAIN_SCENARIOS; i++) {
+      run_gain(GAIN_SCENARIOS[i], false);
+      run_gain(GAIN_SCENARIOS[i], true);
+    }
+
+    ESP_LOGI(TAG, "---");
+    vTaskDelay(pdMS_TO_TICKS(1000));
+  }
+}

--- a/include/pcm_convert.h
+++ b/include/pcm_convert.h
@@ -14,17 +14,17 @@ namespace pcm_convert {
 /// Each output frame is built channel-by-channel. When the output has more channels than the
 /// input, the extra channels reuse the last input channel; when it has fewer, the trailing input
 /// channels are dropped. Bit-depth conversion goes through a Q31 intermediate: widening is exact,
-/// narrowing truncates the low bits (no dithering). When the input and output formats match
-/// exactly this degenerates to a plain memcpy.
+/// narrowing rounds to nearest (the dropped low bits are rounded, not truncated; no dithering).
+/// When the input and output formats match exactly this degenerates to a plain memcpy.
 ///
 /// Sample format: signed PCM, little-endian for multi-byte widths, interleaved across channels.
 /// 8-bit samples are interpreted as int8 (0x00 is silence), not WAV-style uint8.
 ///
 /// The buffers must not overlap, with one supported exception: in-place conversion where `output`
 /// exactly aliases `input` (same pointer). That is supported only when the channel count is
-/// unchanged and the output is no wider than the input (`output_bps <= input_bps`) — i.e.
+/// unchanged and the output is no wider than the input (`output_bps <= input_bps`); i.e.,
 /// same-format (a no-op) or narrowing. Such a call is a single forward pass whose write pointer
-/// never overtakes the still-unread input. An exactly-aliased call that is *not* in that supported
+/// never overtakes the still-unread input. An exactly-aliased call that is not in that supported
 /// form (in-place widening or any change in channel count) is detected and returns without touching
 /// the buffer, so it is a defined no-op rather than silent corruption. This safety net covers only
 /// exact aliasing; partial overlap (an `output` offset into `input`) is undetectable and remains

--- a/include/pcm_convert.h
+++ b/include/pcm_convert.h
@@ -20,9 +20,19 @@ namespace pcm_convert {
 /// Sample format: signed PCM, little-endian for multi-byte widths, interleaved across channels.
 /// 8-bit samples are interpreted as int8 (0x00 is silence), not WAV-style uint8.
 ///
-/// The buffers must not overlap. Misaligned pointers are handled correctly via a runtime
-/// dispatch, but aligning each pointer to its sample width (2 bytes for 16-bit, 4 bytes for
-/// 32-bit) lets the function take the wide-load fast path on architectures like Xtensa.
+/// The buffers must not overlap, with one supported exception: in-place conversion where `output`
+/// exactly aliases `input` (same pointer). That is supported only when the channel count is
+/// unchanged and the output is no wider than the input (`output_bps <= input_bps`) — i.e.
+/// same-format (a no-op) or narrowing. Such a call is a single forward pass whose write pointer
+/// never overtakes the still-unread input. An exactly-aliased call that is *not* in that supported
+/// form (in-place widening or any change in channel count) is detected and returns without touching
+/// the buffer, so it is a defined no-op rather than silent corruption. This safety net covers only
+/// exact aliasing; partial overlap (an `output` offset into `input`) is undetectable and remains
+/// unsupported (undefined behavior).
+///
+/// Misaligned pointers are handled correctly via a runtime dispatch, but aligning each pointer to
+/// its sample width (2 bytes for 16-bit, 4 bytes for 32-bit) lets the function take the wide-load
+/// fast path on architectures like Xtensa.
 ///
 /// @note The total byte count `frames * input_channels * input_bps` must fit in `size_t`, and
 /// `frames * input_channels` must fit in `uint32_t`. On 32-bit targets the first condition implies
@@ -31,7 +41,8 @@ namespace pcm_convert {
 /// `uint32_t` directly. The caller is responsible for not exceeding these limits.
 ///
 /// @param input Source buffer of interleaved samples.
-/// @param output Destination buffer (must not alias the input).
+/// @param output Destination buffer. Must not overlap the input, except it may exactly alias it
+/// (`output == input`) for same-format or narrowing conversions that keep the channel count.
 /// @param input_bps Source sample width in bytes: 1, 2, 3, or 4. Other values are a no-op.
 /// @param input_channels Number of source channels (must be >= 1).
 /// @param output_bps Destination sample width in bytes: 1, 2, 3, or 4. Other values are a no-op.

--- a/src/mixer.cpp
+++ b/src/mixer.cpp
@@ -1,6 +1,7 @@
 #include "mixer.h"
 
 #include <algorithm>
+#include <cstdint>
 
 #include "compiler.h"
 #include "q31_utils.h"
@@ -15,19 +16,14 @@ using internal::fast_unpack_to_q31;
 using internal::pack_q31;
 using internal::unpack_to_q31;
 
-// Mix in Q30 so the sum stays in a 32-bit register; the right shift loses 1 LSB per input.
-constexpr int32_t Q30_MIN = -(INT32_C(1) << 30);
-constexpr int32_t Q30_MAX = (INT32_C(1) << 30) - 1;
-
-// Sum two Q31 inputs into a saturated Q31 output. Each input is halved before adding so the sum
-// stays in int32; the result is clamped to the Q30 range and shifted back to Q31. The shift goes
-// through uint32_t because left-shifting a negative signed value is undefined before C++20; the
-// clamp guarantees the shifted result still fits in int32.
-EAL_HOT inline int32_t mix_q31(int32_t primary_q31, int32_t secondary_q31) {
-  const int32_t sum_q30 = (primary_q31 >> 1) + (secondary_q31 >> 1);
-  const int32_t clamped_q30 = std::min(std::max(sum_q30, Q30_MIN), Q30_MAX);
-  return static_cast<int32_t>(static_cast<uint32_t>(clamped_q30) << 1);
-}
+// Each input is right-shifted MIX_SHIFT bits before the two are summed. Two bits of headroom (vs.
+// the minimum of one) leave enough room that the rounding term can be added without overflowing
+// int32, so the whole mix stays in 32-bit math. The cost is 2 discarded LSB of true 31/32-bit-deep
+// input content (inaudible); 16- and 24-bit inputs are unaffected since they carry trailing zeros.
+// The clamp range is Q(31 - MIX_SHIFT): MIX_MAX maps exactly to full scale at every output depth.
+constexpr int MIX_SHIFT = 2;
+constexpr int32_t MIX_MIN = -(INT32_C(1) << (31 - MIX_SHIFT));
+constexpr int32_t MIX_MAX = (INT32_C(1) << (31 - MIX_SHIFT)) - 1;
 
 // Pick the fast (aligned wide-load) or byte-wise variant at compile time. The `Aligned` template
 // flag is set by the runtime alignment check in mix_frames(); both branches fold away at -O2.
@@ -46,37 +42,60 @@ template<size_t Bps, bool Aligned> EAL_HOT inline void pack(int32_t sample, uint
   }
 }
 
-// Hot path: the two inputs and the output all share one sample width. Templating on a single `Bps`
-// (instead of the full primary x secondary x output matrix) keeps this fully inlined and a
-// zero-overhead-loop candidate while collapsing the instantiation count from 4*4*4 to 4 per
-// alignment variant.
+// Sum two Q31 inputs, round for a Bps-byte output, and store the result. Each input is shifted
+// right by MIX_SHIFT before adding so the pre-round sum plus the rounding term stay within int32;
+// the rounding term is added before the clamp, so the single [MIX_MIN, MIX_MAX] clamp guards both
+// the mix saturation and the rounding overflow: MIX_MAX maps exactly to full scale at the output
+// depth (MIX_MAX >> ((4-Bps)*8 - MIX_SHIFT) == output max), so a rounded full-scale sample cannot
+// wrap. The final left shift goes through uint32_t because shifting a negative signed value is
+// undefined before C++20; the clamp guarantees the shifted result still fits in int32.
+template<size_t Bps, bool Aligned>
+EAL_HOT inline void mix_and_pack(int32_t primary_q31, int32_t secondary_q31, uint8_t *out) {
+  constexpr int net_shift = (4 - static_cast<int>(Bps)) * 8 - MIX_SHIFT;
+  // net_shift <= 0 only for Bps == 4 (32-bit output), which does not narrow and must not round, so
+  // round_term is 0 there; the `> 0` guard also keeps the shift below from going negative. The term
+  // is added unconditionally in the sum, so this 0 is load-bearing, not just a dead-branch value.
+  // TODO(C++17): an `if constexpr (net_shift > 0)` here would discard the Bps == 4 case outright and
+  // let round_term drop its guard.
+  constexpr int32_t round_term = net_shift > 0 ? (INT32_C(1) << (net_shift - 1)) : 0;
+  const int32_t sum = (primary_q31 >> MIX_SHIFT) + (secondary_q31 >> MIX_SHIFT) + round_term;
+  const int32_t clamped = std::min(std::max(sum, MIX_MIN), MIX_MAX);
+  pack<Bps, Aligned>(static_cast<int32_t>(static_cast<uint32_t>(clamped) << MIX_SHIFT), out);
+}
+
+// Hot path: the two inputs and the output all share one sample width, so a single `Bps` template
+// parameter covers all three and the unpack/pack stay fully inlined.
 template<size_t Bps, bool Aligned>
 EAL_HOT void mix_frames_same_bps(const uint8_t *pri_ptr, uint8_t primary_channels, const uint8_t *sec_ptr,
                                  uint8_t secondary_channels, uint8_t *out_ptr, uint8_t output_channels,
                                  uint32_t frames) {
   const uint8_t max_primary_channel_index = primary_channels - 1;
   const uint8_t max_secondary_channel_index = secondary_channels - 1;
+  const size_t pri_stride = static_cast<size_t>(primary_channels) * Bps;
+  const size_t sec_stride = static_cast<size_t>(secondary_channels) * Bps;
+  const size_t out_stride = static_cast<size_t>(output_channels) * Bps;
 
-  for (uint32_t frame = 0; frame < frames; ++frame) {
-    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
-      const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
-      const int32_t primary_q31 = unpack<Bps, Aligned>(pri_ptr + pri_ch * Bps);
+  for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+    const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
+    const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
+    const uint8_t *pri = pri_ptr + pri_ch * Bps;
+    const uint8_t *sec = sec_ptr + sec_ch * Bps;
+    uint8_t *out = out_ptr + out_ch * Bps;
 
-      const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
-      const int32_t secondary_q31 = unpack<Bps, Aligned>(sec_ptr + sec_ch * Bps);
-
-      pack<Bps, Aligned>(mix_q31(primary_q31, secondary_q31), out_ptr + out_ch * Bps);
+    for (uint32_t frame = 0; frame < frames; ++frame) {
+      const int32_t primary_q31 = unpack<Bps, Aligned>(pri);
+      const int32_t secondary_q31 = unpack<Bps, Aligned>(sec);
+      mix_and_pack<Bps, Aligned>(primary_q31, secondary_q31, out);
+      pri += pri_stride;
+      sec += sec_stride;
+      out += out_stride;
     }
-    pri_ptr += primary_channels * Bps;
-    sec_ptr += secondary_channels * Bps;
-    out_ptr += output_channels * Bps;
   }
 }
 
-// Runtime-width unpack for the mismatched-width path. A width switch on a loop-invariant `bps`
-// (well predicted) replaces the per-input-width template axis, so only the output width and the
-// alignment flag stay as template parameters. The `Aligned` flag selects the wide-load variant;
-// callers guarantee each buffer is aligned to its own width before picking it.
+// Runtime-width unpack for the mismatched-width path: a switch on `bps` keeps the input width off
+// the template axis. The `Aligned` flag selects the wide-load variant; callers guarantee each
+// buffer is aligned to its own width before picking it.
 template<bool Aligned> EAL_HOT inline int32_t unpack_runtime(const uint8_t *data, uint8_t bps) {
   switch (bps) {
     case 1:
@@ -91,28 +110,33 @@ template<bool Aligned> EAL_HOT inline int32_t unpack_runtime(const uint8_t *data
 }
 
 // Mismatched-width path: the three buffers do not share one sample width. The output width and
-// alignment are template parameters (so the per-output-sample pack is the inlined wide store and
-// carries no switch), while the two input widths are resolved by the runtime switch above.
+// alignment stay template parameters (so the pack inlines); the two input widths are resolved by
+// the runtime switch above.
 template<size_t OutputBps, bool Aligned>
 EAL_HOT void mix_frames_generic(const uint8_t *pri_ptr, uint8_t primary_bps, uint8_t primary_channels,
                                 const uint8_t *sec_ptr, uint8_t secondary_bps, uint8_t secondary_channels,
                                 uint8_t *out_ptr, uint8_t output_channels, uint32_t frames) {
   const uint8_t max_primary_channel_index = primary_channels - 1;
   const uint8_t max_secondary_channel_index = secondary_channels - 1;
+  const size_t pri_stride = static_cast<size_t>(primary_channels) * primary_bps;
+  const size_t sec_stride = static_cast<size_t>(secondary_channels) * secondary_bps;
+  const size_t out_stride = static_cast<size_t>(output_channels) * OutputBps;
 
-  for (uint32_t frame = 0; frame < frames; ++frame) {
-    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
-      const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
-      const int32_t primary_q31 = unpack_runtime<Aligned>(pri_ptr + pri_ch * primary_bps, primary_bps);
+  for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+    const uint8_t pri_ch = std::min<uint8_t>(out_ch, max_primary_channel_index);
+    const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
+    const uint8_t *pri = pri_ptr + pri_ch * primary_bps;
+    const uint8_t *sec = sec_ptr + sec_ch * secondary_bps;
+    uint8_t *out = out_ptr + out_ch * OutputBps;
 
-      const uint8_t sec_ch = std::min<uint8_t>(out_ch, max_secondary_channel_index);
-      const int32_t secondary_q31 = unpack_runtime<Aligned>(sec_ptr + sec_ch * secondary_bps, secondary_bps);
-
-      pack<OutputBps, Aligned>(mix_q31(primary_q31, secondary_q31), out_ptr + out_ch * OutputBps);
+    for (uint32_t frame = 0; frame < frames; ++frame) {
+      const int32_t primary_q31 = unpack_runtime<Aligned>(pri, primary_bps);
+      const int32_t secondary_q31 = unpack_runtime<Aligned>(sec, secondary_bps);
+      mix_and_pack<OutputBps, Aligned>(primary_q31, secondary_q31, out);
+      pri += pri_stride;
+      sec += sec_stride;
+      out += out_stride;
     }
-    pri_ptr += primary_channels * primary_bps;
-    sec_ptr += secondary_channels * secondary_bps;
-    out_ptr += output_channels * OutputBps;
   }
 }
 

--- a/src/pcm_convert.cpp
+++ b/src/pcm_convert.cpp
@@ -1,6 +1,7 @@
 #include "pcm_convert.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 
 #include "compiler.h"
@@ -33,55 +34,45 @@ template<size_t Bps, bool Aligned> EAL_HOT inline void pack(int32_t sample, uint
   }
 }
 
+// Round a left-justified Q31 sample for storage as OutputBps bytes. pack() drops the low
+// (4 - OutputBps) bytes by truncation; adding half the discarded range first rounds to nearest.
+// Near-full-scale samples must not wrap when the round term pushes them past +full-scale. Rather
+// than a compare-and-branch saturating add (which breaks the unrolled loop's scheduling on the
+// in-order pipeline), clamp the input down to (INT32_MAX - term) with a single branchless min so the
+// unconditional add that follows can never overflow int32. This is bit-identical to a saturating add
+// (a sample already at the cap lands exactly on INT32_MAX) and needs no shifts. Compile-time no-op
+// when OutputBps >= InputBps: the dropped bits are already zero (unpack left-justifies), so widening
+// and same-width conversions pay nothing and only narrowing rounds.
+template<size_t InputBps, size_t OutputBps> EAL_HOT inline int32_t round_for_output(int32_t sample) {
+  // TODO(C++17): make this `if constexpr` so the OutputBps >= InputBps branch is discarded rather
+  // than relying on -O2 to elide it; the shift > 0 guard below could then drop to plain `shift - 1`.
+  if (OutputBps < InputBps) {
+    constexpr int shift = (4 - static_cast<int>(OutputBps)) * 8;
+    // Clamp so the unused (OutputBps == 4, shift == 0) branch forms no negative shift.
+    constexpr int32_t term = INT32_C(1) << (shift > 0 ? shift - 1 : 0);
+    return std::min(sample, INT32_MAX - term) + term;
+  }
+  return sample;
+}
+
+// The conversion loop for every channel layout. Each output channel maps to a fixed input channel,
+// so the channel loop is outermost and the frame loop innermost.
 template<size_t InputBps, size_t OutputBps, bool Aligned>
 EAL_HOT void copy_frames_generic(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_channels,
                                  uint8_t output_channels, uint32_t frames) {
   const uint8_t max_input_channel_index = input_channels - 1;
-  for (uint32_t frame = 0; frame < frames; ++frame) {
-    for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
-      const uint8_t in_ch = std::min<uint8_t>(out_ch, max_input_channel_index);
-      const int32_t q31 = unpack<InputBps, Aligned>(in_ptr + in_ch * InputBps);
-      pack<OutputBps, Aligned>(q31, out_ptr + out_ch * OutputBps);
+  const size_t in_stride = static_cast<size_t>(input_channels) * InputBps;
+  const size_t out_stride = static_cast<size_t>(output_channels) * OutputBps;
+  for (uint8_t out_ch = 0; out_ch < output_channels; ++out_ch) {
+    const uint8_t in_ch = std::min<uint8_t>(out_ch, max_input_channel_index);
+    const uint8_t *in = in_ptr + in_ch * InputBps;
+    uint8_t *out = out_ptr + out_ch * OutputBps;
+    for (uint32_t frame = 0; frame < frames; ++frame) {
+      pack<OutputBps, Aligned>(round_for_output<InputBps, OutputBps>(unpack<InputBps, Aligned>(in)), out);
+      in += in_stride;
+      out += out_stride;
     }
-    in_ptr += input_channels * InputBps;
-    out_ptr += output_channels * OutputBps;
   }
-}
-
-// Channel-count-specialized variant. Hard-coding the channel counts lets the compiler unroll the
-// inner channel loop, leaving a single straight-line outer loop that Xtensa can lower to a
-// hardware zero-overhead loop (LOOPNEZ/LOOPGTZ).
-template<size_t InputBps, size_t OutputBps, uint8_t InputChannels, uint8_t OutputChannels, bool Aligned>
-EAL_HOT void copy_frames_fixed_channels(const uint8_t *in_ptr, uint8_t *out_ptr, uint32_t frames) {
-  constexpr uint8_t MAX_INPUT_CHANNEL_INDEX = InputChannels - 1;
-  for (uint32_t frame = 0; frame < frames; ++frame) {
-    for (uint8_t out_ch = 0; out_ch < OutputChannels; ++out_ch) {
-      const uint8_t in_ch = std::min<uint8_t>(out_ch, MAX_INPUT_CHANNEL_INDEX);
-      const int32_t q31 = unpack<InputBps, Aligned>(in_ptr + in_ch * InputBps);
-      pack<OutputBps, Aligned>(q31, out_ptr + out_ch * OutputBps);
-    }
-    in_ptr += InputChannels * InputBps;
-    out_ptr += OutputChannels * OutputBps;
-  }
-}
-
-template<size_t InputBps, size_t OutputBps, bool Aligned>
-EAL_HOT void copy_frames_dispatch_channels(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_channels,
-                                           uint8_t output_channels, uint32_t frames) {
-  // Matching channel counts are rewritten to the 1->1 path by copy_frames(), so only the
-  // mismatched mono/stereo remaps need a fixed-channel specialization here. The 1->1 case still
-  // arrives via that rewrite (it carries frames*channels samples).
-  if (output_channels == 1) {
-    if (input_channels == 1)
-      return copy_frames_fixed_channels<InputBps, OutputBps, 1, 1, Aligned>(in_ptr, out_ptr, frames);
-    if (input_channels == 2)
-      return copy_frames_fixed_channels<InputBps, OutputBps, 2, 1, Aligned>(in_ptr, out_ptr, frames);
-  } else if (output_channels == 2) {
-    if (input_channels == 1)
-      return copy_frames_fixed_channels<InputBps, OutputBps, 1, 2, Aligned>(in_ptr, out_ptr, frames);
-  }
-  // Fallback for unusual channel remaps (3+ channels in or out, with differing counts).
-  copy_frames_generic<InputBps, OutputBps, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
 }
 
 template<size_t InputBps, bool Aligned>
@@ -89,16 +80,16 @@ void copy_frames_dispatch_output(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_
                                  uint8_t output_channels, uint32_t frames) {
   switch (output_bps) {
     case 1:
-      copy_frames_dispatch_channels<InputBps, 1, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      copy_frames_generic<InputBps, 1, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
       break;
     case 2:
-      copy_frames_dispatch_channels<InputBps, 2, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      copy_frames_generic<InputBps, 2, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
       break;
     case 3:
-      copy_frames_dispatch_channels<InputBps, 3, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      copy_frames_generic<InputBps, 3, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
       break;
     case 4:
-      copy_frames_dispatch_channels<InputBps, 4, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
+      copy_frames_generic<InputBps, 4, Aligned>(in_ptr, out_ptr, input_channels, output_channels, frames);
       break;
   }
 }
@@ -122,6 +113,185 @@ void copy_frames_dispatch_input(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t
   }
 }
 
+template<size_t InputBps, size_t OutputBps>
+EAL_HOT void copy_frames_mono_to_stereo(const uint8_t *in_ptr, uint8_t *out_ptr, uint32_t frames) {
+  uint32_t frame = 0;
+  const uint32_t frames_unrolled = frames & ~7u;  // unroll by 8
+  for (; frame < frames_unrolled; frame += 8) {
+    const int32_t sample1 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr));
+    const int32_t sample2 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + InputBps));
+    const int32_t sample3 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 2 * InputBps));
+    const int32_t sample4 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 3 * InputBps));
+    const int32_t sample5 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 4 * InputBps));
+    const int32_t sample6 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 5 * InputBps));
+    const int32_t sample7 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 6 * InputBps));
+    const int32_t sample8 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 7 * InputBps));
+    fast_pack_q31<OutputBps>(sample1, out_ptr);
+    fast_pack_q31<OutputBps>(sample1, out_ptr + OutputBps);
+    fast_pack_q31<OutputBps>(sample2, out_ptr + 2 * OutputBps);
+    fast_pack_q31<OutputBps>(sample2, out_ptr + 3 * OutputBps);
+    fast_pack_q31<OutputBps>(sample3, out_ptr + 4 * OutputBps);
+    fast_pack_q31<OutputBps>(sample3, out_ptr + 5 * OutputBps);
+    fast_pack_q31<OutputBps>(sample4, out_ptr + 6 * OutputBps);
+    fast_pack_q31<OutputBps>(sample4, out_ptr + 7 * OutputBps);
+    fast_pack_q31<OutputBps>(sample5, out_ptr + 8 * OutputBps);
+    fast_pack_q31<OutputBps>(sample5, out_ptr + 9 * OutputBps);
+    fast_pack_q31<OutputBps>(sample6, out_ptr + 10 * OutputBps);
+    fast_pack_q31<OutputBps>(sample6, out_ptr + 11 * OutputBps);
+    fast_pack_q31<OutputBps>(sample7, out_ptr + 12 * OutputBps);
+    fast_pack_q31<OutputBps>(sample7, out_ptr + 13 * OutputBps);
+    fast_pack_q31<OutputBps>(sample8, out_ptr + 14 * OutputBps);
+    fast_pack_q31<OutputBps>(sample8, out_ptr + 15 * OutputBps);
+    in_ptr += 8 * InputBps;
+    out_ptr += 16 * OutputBps;
+  }
+  for (; frame < frames; ++frame) {
+    const int32_t sample = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr));
+    fast_pack_q31<OutputBps>(sample, out_ptr);
+    fast_pack_q31<OutputBps>(sample, out_ptr + OutputBps);
+    in_ptr += InputBps;
+    out_ptr += 2 * OutputBps;
+  }
+}
+
+template<size_t InputBps>
+void copy_frames_mono_to_stereo_dispatch_output(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t output_bps,
+                                                uint32_t frames) {
+  // 1-byte widths are not specialized here; copy_frames() routes them to the generic loop.
+  switch (output_bps) {
+    case 2:
+      copy_frames_mono_to_stereo<InputBps, 2>(in_ptr, out_ptr, frames);
+      break;
+    case 3:
+      copy_frames_mono_to_stereo<InputBps, 3>(in_ptr, out_ptr, frames);
+      break;
+    case 4:
+      copy_frames_mono_to_stereo<InputBps, 4>(in_ptr, out_ptr, frames);
+      break;
+  }
+}
+
+void copy_frames_mono_to_stereo_dispatch(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_bps, uint8_t output_bps,
+                                         uint32_t frames) {
+  switch (input_bps) {
+    case 2:
+      copy_frames_mono_to_stereo_dispatch_output<2>(in_ptr, out_ptr, output_bps, frames);
+      break;
+    case 3:
+      copy_frames_mono_to_stereo_dispatch_output<3>(in_ptr, out_ptr, output_bps, frames);
+      break;
+    case 4:
+      copy_frames_mono_to_stereo_dispatch_output<4>(in_ptr, out_ptr, output_bps, frames);
+      break;
+  }
+}
+
+// Whether a 1->1 conversion of these widths uses the byte-wise unpack/pack (any 3-byte side) rather
+// than the wide load/store (both sides 2 or 4 byte). Byte-wise sides need many more registers per
+// sample, so they take a shallower unroll.
+template<size_t InputBps, size_t OutputBps> struct mono_bytewise {
+  static constexpr bool value = (InputBps == 3 || OutputBps == 3);
+};
+
+// Flat 1->1 bit-depth conversion; carries the bulk of narrowing/widening throughput. The unrolled
+// body loads into named locals (not an int32_t[], which spills to the stack) then stores in a
+// separate phase, exposing independent chains the in-order pipeline can overlap. Only the wide-load
+// 2/4-byte widths take this deep 8-wide unroll; byte-wise 3-byte uses copy_frames_mono_narrow, whose
+// shallower unroll avoids spilling the register window.
+template<size_t InputBps, size_t OutputBps>
+EAL_HOT void copy_frames_mono(const uint8_t *in_ptr, uint8_t *out_ptr, uint32_t frames) {
+  uint32_t frame = 0;
+  const uint32_t frames_unrolled = frames & ~7u;  // unroll by 8
+  for (; frame < frames_unrolled; frame += 8) {
+    const int32_t sample1 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr));
+    const int32_t sample2 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + InputBps));
+    const int32_t sample3 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 2 * InputBps));
+    const int32_t sample4 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 3 * InputBps));
+    const int32_t sample5 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 4 * InputBps));
+    const int32_t sample6 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 5 * InputBps));
+    const int32_t sample7 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 6 * InputBps));
+    const int32_t sample8 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + 7 * InputBps));
+    fast_pack_q31<OutputBps>(sample1, out_ptr);
+    fast_pack_q31<OutputBps>(sample2, out_ptr + OutputBps);
+    fast_pack_q31<OutputBps>(sample3, out_ptr + 2 * OutputBps);
+    fast_pack_q31<OutputBps>(sample4, out_ptr + 3 * OutputBps);
+    fast_pack_q31<OutputBps>(sample5, out_ptr + 4 * OutputBps);
+    fast_pack_q31<OutputBps>(sample6, out_ptr + 5 * OutputBps);
+    fast_pack_q31<OutputBps>(sample7, out_ptr + 6 * OutputBps);
+    fast_pack_q31<OutputBps>(sample8, out_ptr + 7 * OutputBps);
+    in_ptr += 8 * InputBps;
+    out_ptr += 8 * OutputBps;
+  }
+  for (; frame < frames; ++frame) {
+    const int32_t sample = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr));
+    fast_pack_q31<OutputBps>(sample, out_ptr);
+    in_ptr += InputBps;
+    out_ptr += OutputBps;
+  }
+}
+
+// Shallow (2-wide) unroll for the byte-wise 3-byte widths: the byte-wise unpack/pack needs several
+// registers per sample, so an 8-wide unroll spills the window. Two independent chains still give the
+// in-order pipeline something to overlap without overflowing the registers.
+template<size_t InputBps, size_t OutputBps>
+EAL_HOT void copy_frames_mono_narrow(const uint8_t *in_ptr, uint8_t *out_ptr, uint32_t frames) {
+  uint32_t frame = 0;
+  const uint32_t frames_unrolled = frames & ~1u;  // unroll by 2
+  for (; frame < frames_unrolled; frame += 2) {
+    const int32_t sample1 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr));
+    const int32_t sample2 = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr + InputBps));
+    fast_pack_q31<OutputBps>(sample1, out_ptr);
+    fast_pack_q31<OutputBps>(sample2, out_ptr + OutputBps);
+    in_ptr += 2 * InputBps;
+    out_ptr += 2 * OutputBps;
+  }
+  for (; frame < frames; ++frame) {
+    const int32_t sample = round_for_output<InputBps, OutputBps>(fast_unpack_to_q31<InputBps>(in_ptr));
+    fast_pack_q31<OutputBps>(sample, out_ptr);
+    in_ptr += InputBps;
+    out_ptr += OutputBps;
+  }
+}
+
+template<size_t InputBps, size_t OutputBps>
+inline void copy_frames_mono_select(const uint8_t *in_ptr, uint8_t *out_ptr, uint32_t frames) {
+  if (mono_bytewise<InputBps, OutputBps>::value) {
+    copy_frames_mono_narrow<InputBps, OutputBps>(in_ptr, out_ptr, frames);
+  } else {
+    copy_frames_mono<InputBps, OutputBps>(in_ptr, out_ptr, frames);
+  }
+}
+
+template<size_t InputBps>
+void copy_frames_mono_dispatch_output(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t output_bps, uint32_t frames) {
+  switch (output_bps) {
+    case 2:
+      copy_frames_mono_select<InputBps, 2>(in_ptr, out_ptr, frames);
+      break;
+    case 3:
+      copy_frames_mono_select<InputBps, 3>(in_ptr, out_ptr, frames);
+      break;
+    case 4:
+      copy_frames_mono_select<InputBps, 4>(in_ptr, out_ptr, frames);
+      break;
+  }
+}
+
+void copy_frames_mono_dispatch(const uint8_t *in_ptr, uint8_t *out_ptr, uint8_t input_bps, uint8_t output_bps,
+                               uint32_t frames) {
+  switch (input_bps) {
+    case 2:
+      copy_frames_mono_dispatch_output<2>(in_ptr, out_ptr, output_bps, frames);
+      break;
+    case 3:
+      copy_frames_mono_dispatch_output<3>(in_ptr, out_ptr, output_bps, frames);
+      break;
+    case 4:
+      copy_frames_mono_dispatch_output<4>(in_ptr, out_ptr, output_bps, frames);
+      break;
+  }
+}
+
 // Required alignment for a sample width: 2 bytes for 16-bit (mask 0x1), 4 bytes for 32-bit (mask
 // 0x3). 1- and 3-byte widths are byte-wise and have no alignment requirement.
 inline uintptr_t alignment_mask(uint8_t bps) {
@@ -139,8 +309,22 @@ void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8
     return;
   }
 
+  // In-place conversion (output exactly aliases input) is supported only when the channel layout is
+  // unchanged and the output is no wider than the input: that conversion is a single forward pass
+  // whose output stride is no larger than its input stride, so the write pointer can never overtake
+  // the still-unread input. Widening or a channel-count change would overwrite input bytes a later
+  // read still needs and corrupt the buffer. This only catches exact aliasing; partial overlap (output 
+  // offset into input) is undetectable here and remains the caller's responsibility (see the header).
+  if (input == output && !(input_channels == output_channels && output_bps <= input_bps)) {
+    return;
+  }
+
   if (input_bps == output_bps && input_channels == output_channels) {
-    std::memcpy(output, input, static_cast<size_t>(frames) * input_channels * input_bps);
+    // memcpy with src == dst is undefined behavior even though it is a no-op in practice; skip it
+    // for the in-place same-format call, which has nothing to do anyway.
+    if (input != output) {
+      std::memcpy(output, input, static_cast<size_t>(frames) * input_channels * input_bps);
+    }
     return;
   }
 
@@ -160,6 +344,23 @@ void copy_frames(const uint8_t *input, uint8_t *output, uint8_t input_bps, uint8
   // requires; otherwise fall back to the byte-wise path.
   const bool aligned = (reinterpret_cast<uintptr_t>(input) & alignment_mask(input_bps)) == 0 &&
                        (reinterpret_cast<uintptr_t>(output) & alignment_mask(output_bps)) == 0;
+
+  // Mono to stereo on aligned buffers with 2-, 3-, or 4-byte samples takes a dedicated broadcast
+  // that unpacks each input sample once and stores it to both output channels. Every other layout,
+  // 1-byte widths, and all misaligned buffers go through the generic loop.
+  if (aligned && input_channels == 1 && output_channels == 2 && input_bps >= 2 && output_bps >= 2) {
+    copy_frames_mono_to_stereo_dispatch(input, output, input_bps, output_bps, frames);
+    return;
+  }
+
+  // Flat 1->1 conversion (matching-channel cases were flattened above) takes the unrolled mono path
+  // for 2-, 3-, and 4-byte widths. The unroll depth is chosen per width (deep for the wide-load 2-
+  // and 4-byte widths, shallow for byte-wise 3-byte) so 3-byte does not spill its register window.
+  // 1-byte widths and misaligned buffers fall through to the generic loop.
+  if (aligned && input_channels == 1 && output_channels == 1 && input_bps >= 2 && output_bps >= 2) {
+    copy_frames_mono_dispatch(input, output, input_bps, output_bps, frames);
+    return;
+  }
 
   if (aligned) {
     copy_frames_dispatch_input<true>(input, output, input_bps, output_bps, input_channels, output_channels, frames);


### PR DESCRIPTION
Lots of general improvements:

- Optimizes the PCM convert and mixer paths by transposing the channel and sample loops. 
- Reduces quantization noise by adding a fixed point rounding term whenever any bit depth is narrowed via shifting. 
- Adds a benchmark example to measure different scenarios.

The library is now slightly smaller in flash size, as this PR reduces the number of template instantiations.

Almost all scenarios are faster (or stays the same). The only case where it is slower is PCM convert with bit depth narrowing (and `input channels == output channels`). This is because of the new rounding approach. The quality improvement is worth the speed trade-off.

Benchmarks on an ESP32-S3: 
## `mixer::mix_frames` is uniformly faster (1.4×–3.5×)

| Case | Baseline (ns/frame) | New (ns/frame) | Speedup |
|---|---|---|---|
| 2b1 + 2b1 → 2b1, aligned | 175.59 | 50.60 | **3.47×** |
| 2b2 + 2b2 → 2b2, aligned | 263.14 | 100.72 | **2.61×** |
| 2b2 + 2b1 → 2b2, aligned | 263.14 | 100.72 | **2.61×** |
| 2b1 + 2b1 → 2b1, misaligned | 229.79 | 117.30 | 1.96× |
| 2b2 + 4b2 → 2b2, misaligned | 696.75 | 367.62 | 1.90× |
| 2b2 + 4b2 → 2b2, aligned | 429.90 | 234.21 | 1.84× |
| 4b2 + 2b2 → 4b2, aligned | 404.90 | 225.89 | 1.79× |
| 4b2 + 2b2 → 4b2, misaligned | 667.55 | 392.63 | 1.70× |
| 2b2 + 2b2 → 2b2, misaligned | 359.04 | 234.12 | 1.53× |
| 2b2 + 2b1 → 2b2, misaligned | 359.04 | 234.12 | 1.53× |
| 3b2 + 3b2 → 3b2, aligned/misaligned | 446.6 | 317.60 | 1.41× |

## `pcm_convert::copy_frame` is faster for these cases

| Case | Baseline (ns/frame) | New (ns/frame) | Speedup |
|---|---|---|---|
| 2b1 → 4b2, aligned | 42.10 | 18.79 | **2.24×** |
| 2b1 → 2b2 (upmix), aligned | 25.44 | 14.62 | 1.74× |
| 2b2 → 2b1 (downmix), misaligned | 79.62 | 46.30 | 1.72× |
| 1b2 → 2b2, misaligned | 67.09 | 42.16 | 1.59× |
| 2b2 → 4b2 (widen), misaligned | 167.11 | 108.82 | 1.54× |
| 2b2 → 4b2 (widen), aligned | 42.04 | 28.72 | 1.46× |
| 2b1 → 2b2 (upmix), misaligned | 117.15 | 92.23 | 1.27× |
| 2b2 → 3b2, misaligned | 125.44 | 100.47 | 1.25× |
| 2b1 → 4b2, misaligned | 133.81 | 108.89 | 1.23× |
| 2b2 → 3b2, aligned | 58.72 | 50.61 | 1.16× |
| 4b2 → 2b2 (narrow), misaligned | 200.53 | 183.91 | 1.09× |
| pure copy / 1b2→2b2 aligned / downmix aligned | — | — | ~1.00× (unchanged) |

## `pcm_convert::copy_frame` is slower for these cases
| Case | Baseline (ns/frame) | New (ns/frame) | Change |
|---|---|---|---|
| 4b2 → 2b2 (narrow), **aligned** | 33.75 | 47.52 | **0.71× (≈41% slower)** |
| 3b2 → 2b2, aligned | 100.47 | 113.14 | 0.89× (≈13% slower) |
| 3b2 → 2b2, misaligned | 142.15 | 167.23 | 0.85× (≈18% slower) |