### PR TITLE
Scope resampler flags to an enum instead of leaking global macros

### DIFF
--- a/include/art_resampler.h
+++ b/include/art_resampler.h
@@ -18,9 +18,15 @@
 namespace esp_audio_libs {
 namespace art_resampler {
 
-#define SUBSAMPLE_INTERPOLATE 0x1
-#define BLACKMAN_HARRIS 0x2
-#define INCLUDE_LOWPASS 0x4
+// Flags for the `flags` parameter of resampleInit(). An enum rather than #defines so the
+// names stay scoped to this namespace instead of leaking into the global preprocessor
+// namespace, where common identifiers (e.g. BLACKMAN_HARRIS) collide with other libraries.
+// Left as an unscoped enum so the values keep implicitly converting to the int `flags` field.
+enum ResampleFlags {
+  SUBSAMPLE_INTERPOLATE = 0x1,
+  BLACKMAN_HARRIS = 0x2,
+  INCLUDE_LOWPASS = 0x4,
+};
 
 typedef struct {
   int numChannels, numSamples, numFilters, numTaps, inputIndex, flags;

--- a/src/resample/resampler.cpp
+++ b/src/resample/resampler.cpp
@@ -25,11 +25,9 @@ bool Resampler::initialize(ResamplerConfiguration &config) {
   this->number_of_taps_ = config.number_of_taps;
   this->number_of_filters_ = config.number_of_filters;
 
-  this->float_input_buffer_ =
-      (float *) internal::alloc_psram_fallback(this->input_buffer_samples_ * sizeof(float));
+  this->float_input_buffer_ = (float *) internal::alloc_psram_fallback(this->input_buffer_samples_ * sizeof(float));
 
-  this->float_output_buffer_ =
-      (float *) internal::alloc_psram_fallback(this->output_buffer_samples_ * sizeof(float));
+  this->float_output_buffer_ = (float *) internal::alloc_psram_fallback(this->output_buffer_samples_ * sizeof(float));
 
   if ((this->float_input_buffer_ == nullptr) || (this->float_output_buffer_ == nullptr)) {
     return false;
@@ -40,7 +38,7 @@ bool Resampler::initialize(ResamplerConfiguration &config) {
     int flags = 0;
 
     if (config.subsample_interpolate) {
-      flags |= SUBSAMPLE_INTERPOLATE;
+      flags |= art_resampler::SUBSAMPLE_INTERPOLATE;
     }
 
     this->sample_ratio_ = config.target_sample_rate / config.source_sample_rate;
@@ -77,12 +75,12 @@ bool Resampler::initialize(ResamplerConfiguration &config) {
     }
 
     if (this->sample_ratio_ < 1.0f) {
-      this->resampler_ =
-          art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
-                                      this->sample_ratio_ * this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
+      this->resampler_ = art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
+                                                     this->sample_ratio_ * this->lowpass_ratio_,
+                                                     flags | art_resampler::INCLUDE_LOWPASS);
     } else if (this->lowpass_ratio_ < 1.0f) {
       this->resampler_ = art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_,
-                                                     this->lowpass_ratio_, flags | INCLUDE_LOWPASS);
+                                                     this->lowpass_ratio_, flags | art_resampler::INCLUDE_LOWPASS);
     } else {
       this->resampler_ =
           art_resampler::resampleInit(this->channels_, this->number_of_taps_, this->number_of_filters_, 1.0f, flags);


### PR DESCRIPTION
## What

`include/art_resampler.h` (a public header) defines three resampler flags as bare `#define`s:

```cpp
#define SUBSAMPLE_INTERPOLATE 0x1
#define BLACKMAN_HARRIS 0x2
#define INCLUDE_LOWPASS 0x4
```

Although they sit inside `namespace esp_audio_libs::art_resampler`, macros ignore namespaces, so these names leak into the **global preprocessor namespace** for every translation unit that transitively includes this header. `BLACKMAN_HARRIS` in particular is a common identifier and collides with other libraries.

This converts them to an (unscoped) `enum ResampleFlags` in the same namespace. Being unscoped, the values still implicitly convert to the `int flags` field, so all the existing bitwise usage (`|=`, `&`, `~`, `| INCLUDE_LOWPASS`) is unchanged. The only call sites that needed touching are in `resampler.cpp`, which lives in a different namespace (`esp_audio_libs::resampler`) and now qualifies them as `art_resampler::…` — consistent with how it already qualifies every other `art_resampler::` symbol. `art_resampler.cpp` is in the same namespace as the flags, so it needs no changes.

## Why

A real-world collision: ESPHome builds FastLED (whose `fft::Window::BLACKMAN_HARRIS` enumerator) and this library in the same project. In a clang-tidy unity build that includes both headers, the leaked `#define BLACKMAN_HARRIS 0x2` rewrites FastLED's enumerator and breaks the parse. Scoping the names here fixes the root cause so downstream consumers don't have to work around it.

See esphome/esphome#16804 for the downstream context.

## Notes

- No public API behavior change; the enumerator names and values are identical.
- ESPHome's audio component uses the higher-level `Resampler` class and never references these flag names directly, so no coordinated change is required there.
- Touched files reformatted with the repo `.clang-format`.